### PR TITLE
feat: support legacy encryption

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "php": "^7.3",
         "ext-json": "*",
         "guzzlehttp/guzzle": "^6.3",
-        "keboola/object-encryptor": "^0.1.4",
+        "keboola/object-encryptor": "^0.2",
         "keboola/storage-api-client": "^10.6",
         "psr/log": "^1.1",
         "symfony/config": "^4.2",

--- a/src/JobFactory/Job.php
+++ b/src/JobFactory/Job.php
@@ -94,7 +94,7 @@ class Job implements JsonSerializable
 
     public function getTokenDecrypted(): string
     {
-        return $this->objectEncryptorFactory->getEncryptor()->decrypt($this->getToken());
+        return $this->objectEncryptorFactory->getEncryptor(true)->decrypt($this->getToken());
     }
 
     public function getConfigDataDecrypted(): array

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -57,7 +57,7 @@ class ClientTest extends BaseTest
     {
         self::expectException(ClientException::class);
         self::expectExceptionMessage(
-            'Invalid parameters when creating client: Value "-1" is invalid: This value should be 0 or more.'
+            'Invalid parameters when creating client: Value "-1" is invalid: This value should be 0 and 100.'
         );
         new Client(
             new NullLogger(),
@@ -72,7 +72,7 @@ class ClientTest extends BaseTest
     {
         self::expectException(ClientException::class);
         self::expectExceptionMessage(
-            'Invalid parameters when creating client: Value "101" is invalid: This value should be 100 or less.'
+            'Invalid parameters when creating client: Value "101" is invalid: This value should be between 0 and 100.'
         );
         new Client(
             new NullLogger(),

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -57,7 +57,7 @@ class ClientTest extends BaseTest
     {
         self::expectException(ClientException::class);
         self::expectExceptionMessage(
-            'Invalid parameters when creating client: Value "-1" is invalid: This value should be 0 and 100.'
+            'Invalid parameters when creating client: Value "-1" is invalid: This value should be between 0 and 100.'
         );
         new Client(
             new NullLogger(),


### PR DESCRIPTION
updatnuty object encryptor co podporuje on demand legacy encryptor, ktery se pouzije jen pri dekryptovani tokenu
zmeny v tests/ClientTest.php jsou sideeffect fixnutyho bugu v symfony config
