### PR TITLE
fix (Job): getId() must return string

### DIFF
--- a/src/JobFactory/Job.php
+++ b/src/JobFactory/Job.php
@@ -44,7 +44,7 @@ class Job implements JsonSerializable
 
     public function getId(): string
     {
-        return $this->data['id'];
+        return (string) $this->data['id'];
     }
 
     public function getMode(): string


### PR DESCRIPTION
Na public API mi to robi problemy.

![CloudWatch Management Console 2019-12-03 19-27-54](https://user-images.githubusercontent.com/1488015/70078476-08687d80-1603-11ea-84b2-4104b7be9143.png)
