### PR TITLE
fix (Job): getConfigId must be string

### DIFF
--- a/src/JobFactory/Job.php
+++ b/src/JobFactory/Job.php
@@ -39,7 +39,7 @@ class Job implements JsonSerializable
 
     public function getConfigId(): ?string
     {
-        return $this->data['params']['config'] ?? null;
+        return (string) $this->data['params']['config'] ?? null;
     }
 
     public function getId(): string

--- a/tests/ClientFunctionalTest.php
+++ b/tests/ClientFunctionalTest.php
@@ -229,7 +229,6 @@ class ClientFunctionalTest extends BaseTest
             ],
         ]);
         $createdJob = $client->createJob($job);
-        $client = $this->getClient();
         $response = $client->getJobsWithProjectId($job->getProjectId(), 'id:' . $job->getId());
 
         self::assertCount(1, $response);

--- a/tests/JobFactory/JobTest.php
+++ b/tests/JobFactory/JobTest.php
@@ -49,6 +49,12 @@ class JobTest extends BaseTest
     public function testGetConfigId(): void
     {
         self::assertEquals('454124290', $this->getJob()->getConfigId());
+
+        $jobDataWitConfigIdInt = $this->jobData;
+        $jobDataWitConfigIdInt['params']['config'] = (int) 123456789;
+        $configId = $this->getJob($jobDataWitConfigIdInt)->getConfigId();
+        self::assertIsString($configId);
+        self::assertEquals('123456789', $configId);
     }
 
     public function testGetId(): void


### PR DESCRIPTION
FIXES
```
Fatal error: Return value of Keboola\JobQueueInternalClient\JobFactory\Job::getConfigId() must be of the type string or null, int returned in /var/task/vendor/keboola/job-queue-internal-api-php-client/src/JobFactory/Job.php:42
```