### PR TITLE
feat: add runId

### DIFF
--- a/src/JobFactory.php
+++ b/src/JobFactory.php
@@ -119,6 +119,11 @@ class JobFactory
                 ],
                 'result' => [],
             ];
+            if (!empty($data['parentRunId'])) {
+                $jobData['runId'] = $data['parentRunId'] . Job::RUN_ID_DELIMITER . $jobData['id'];
+            } else {
+                $jobData['runId'] = $jobData['id'];
+            }
         } catch (StorageClientException $e) {
             throw new ClientException(
                 'Cannot create job: ' . $e->getMessage() . ' ' . $data['token'],

--- a/src/JobFactory/Job.php
+++ b/src/JobFactory/Job.php
@@ -50,7 +50,7 @@ class Job implements JsonSerializable
             return null;
         } else {
             return (string) $this->data['params']['config'];
-    }
+        }
     }
 
     public function getId(): string
@@ -79,7 +79,7 @@ class Job implements JsonSerializable
             return null;
         } else {
             return (string) $this->data['params']['row'];
-    }
+        }
     }
 
     public function getStatus(): string
@@ -93,7 +93,7 @@ class Job implements JsonSerializable
             return null;
         } else {
             return (string) $this->data['params']['tag'];
-    }
+        }
     }
 
     public function getToken(): string

--- a/src/JobFactory/Job.php
+++ b/src/JobFactory/Job.php
@@ -50,7 +50,7 @@ class Job implements JsonSerializable
             return null;
         } else {
             return (string) $this->data['params']['config'];
-        }
+    }
     }
 
     public function getId(): string
@@ -79,7 +79,7 @@ class Job implements JsonSerializable
             return null;
         } else {
             return (string) $this->data['params']['row'];
-        }
+    }
     }
 
     public function getStatus(): string
@@ -93,7 +93,7 @@ class Job implements JsonSerializable
             return null;
         } else {
             return (string) $this->data['params']['tag'];
-        }
+    }
     }
 
     public function getToken(): string

--- a/src/JobFactory/NewJobDefinition.php
+++ b/src/JobFactory/NewJobDefinition.php
@@ -43,6 +43,7 @@ class NewJobDefinition implements ConfigurationInterface
                 ->end()
                 ->scalarNode('row')->end()
                 ->scalarNode('tag')->end()
+                ->scalarNode('parentRunId')->end()
                 ->arrayNode('configData')->ignoreExtraKeys(false)->end()
             ->end();
         // @formatter:on

--- a/tests/ClientFunctionalTest.php
+++ b/tests/ClientFunctionalTest.php
@@ -80,6 +80,8 @@ class ClientFunctionalTest extends BaseTest
         $tokenInfo = $storageClient->verifyToken();
         self::assertStringStartsWith('KBC::ProjectSecure::', $response['token']['token']);
         unset($response['token']['token']);
+        self::assertNotEmpty($response['runId']);
+        unset($response['runId']);
         $expected = [
             'params' => [
                 'config' => '454124290',

--- a/tests/JobFactory/JobTest.php
+++ b/tests/JobFactory/JobTest.php
@@ -69,17 +69,25 @@ class JobTest extends BaseTest
         self::assertEquals('', $this->getJob()->getParentRunId());
 
         $jobData = $this->jobData;
-        $jobData['runId'] = '1234.5678';
-        self::assertEquals('1234', $this->getJob()->getParentRunId());
+        $jobData['runId'] = '1234.567';
+        self::assertSame('1234', $this->getJob($jobData)->getParentRunId());
+
+        $jobData = $this->jobData;
+        $jobData['runId'] = 1234.567;
+        self::assertSame('1234', $this->getJob($jobData)->getParentRunId());
     }
 
     public function testGetRunId(): void
     {
-        self::assertEquals('123456', $this->getJob()->getRunId());
+        self::assertEquals('123456456', $this->getJob()->getRunId());
 
         $jobData = $this->jobData;
-        $jobData['runId'] = '1234.5678';
-        self::assertEquals('5678', $this->getJob()->getParentRunId());
+        $jobData['runId'] = '1234.567';
+        self::assertEquals('1234.567', $this->getJob($jobData)->getRunId());
+
+        $jobData = $this->jobData;
+        $jobData['runId'] = 1234.567;
+        self::assertEquals('1234.567', $this->getJob($jobData)->getRunId());
     }
 
     public function testGetMode(): void
@@ -161,7 +169,9 @@ class JobTest extends BaseTest
 
     public function testJsonSerialize(): void
     {
-        self::assertEquals($this->jobData, $this->getJob()->jsonSerialize());
+        $expected = $this->jobData;
+        $expected['runId'] = '123456456';
+        self::assertEquals($expected, $this->getJob()->jsonSerialize());
     }
 
     private function getJob(?array $jobData = null): Job

--- a/tests/JobFactory/JobTest.php
+++ b/tests/JobFactory/JobTest.php
@@ -64,6 +64,24 @@ class JobTest extends BaseTest
         self::assertEquals('123456456', $this->getJob()->getId());
     }
 
+    public function testGetParentRunId(): void
+    {
+        self::assertEquals('', $this->getJob()->getParentRunId());
+
+        $jobData = $this->jobData;
+        $jobData['runId'] = '1234.5678';
+        self::assertEquals('1234', $this->getJob()->getParentRunId());
+    }
+
+    public function testGetRunId(): void
+    {
+        self::assertEquals('123456', $this->getJob()->getRunId());
+
+        $jobData = $this->jobData;
+        $jobData['runId'] = '1234.5678';
+        self::assertEquals('5678', $this->getJob()->getParentRunId());
+    }
+
     public function testGetMode(): void
     {
         self::assertEquals('run', $this->getJob()->getMode());

--- a/tests/JobFactory/NewJobDefinitionTest.php
+++ b/tests/JobFactory/NewJobDefinitionTest.php
@@ -29,6 +29,7 @@ class NewJobDefinitionTest extends BaseTest
     {
         $data = [
             'token' => getenv('TEST_STORAGE_API_TOKEN'),
+            'parentRunId' => '12345',
             'config' => '123',
             'component' => 'keboola.test',
             'mode' => 'run',
@@ -73,7 +74,7 @@ class NewJobDefinitionTest extends BaseTest
                 ],
                 'Invalid configuration for path "job.mode": Mode must be one of "run" or "debug".',
             ],
-            'Invalid configData' => [
+                'Invalid configData' => [
                 [
                     'token' => getenv('TEST_STORAGE_API_TOKEN'),
                     'config' => '123',
@@ -113,6 +114,17 @@ class NewJobDefinitionTest extends BaseTest
                     'result' => 'invalid',
                 ],
                 'Invalid type for path "job.result". Expected array, but got string',
+            ],
+            'Invalid run id' => [
+                [
+                    'token' => getenv('TEST_STORAGE_API_TOKEN'),
+                    'parentRunId' => ['123', '345'],
+                    'config' => '123',
+                    'component' => 'keboola.test',
+                    'mode' => 'run',
+                    'tag' => ['234'],
+                ],
+                'Invalid type for path "job.parentRunId". Expected scalar, but got array.',
             ],
         ];
     }

--- a/tests/JobFactory/NewJobDefinitionTest.php
+++ b/tests/JobFactory/NewJobDefinitionTest.php
@@ -74,7 +74,7 @@ class NewJobDefinitionTest extends BaseTest
                 ],
                 'Invalid configuration for path "job.mode": Mode must be one of "run" or "debug".',
             ],
-                'Invalid configData' => [
+            'Invalid configData' => [
                 [
                     'token' => getenv('TEST_STORAGE_API_TOKEN'),
                     'config' => '123',

--- a/tests/JobFactoryTest.php
+++ b/tests/JobFactoryTest.php
@@ -58,6 +58,7 @@ class JobFactoryTest extends BaseTest
         self::assertEquals([], $job->getConfigDataDecrypted());
         self::assertNull($job->getRowId());
         self::assertNull($job->getTag());
+        self::assertEquals($job->getId(), $job->getRunId());
     }
 
     public function testGetTokenLegacyDecrypted(): void
@@ -85,6 +86,7 @@ class JobFactoryTest extends BaseTest
         $factory = $this->getJobFactory();
         $data = [
             'token' => getenv('TEST_STORAGE_API_TOKEN'),
+            'parentRunId' => '2345',
             'config' => '123',
             'component' => 'keboola.test',
             'mode' => 'run',
@@ -103,6 +105,7 @@ class JobFactoryTest extends BaseTest
         self::assertEquals('234', $job->getRowId());
         self::assertEquals(['parameters' => ['foo' => 'bar']], $job->getConfigData());
         self::assertEquals('latest', $job->getTag());
+        self::assertEquals('2345.' . $job->getId(), $job->getRunId());
     }
 
     public function testCreateLegacyJob(): void


### PR DESCRIPTION
Pridava moznost zadat runid pri vyvtvareni jobu
Soucasny chovani je takovy, ze kdyz u jobu zadam runId = 1234, tak po zalozeni ma runId 1234.3456 (stal se child jobem)
Aby to bylo trosku jasnejsi, tak jsem to rovnou pojmenoval parentRunId. Tzn. kdyz u jobu zadam parentRunId = 1234, tak po zalozeni ma runId 1234.3456 (stal se child jobem). runId primo zadat nejde. Pokud neni zadany parentId je runId stejny jako jobId (protoze jsme neprisli na duvod proc by melo byt jiny).

https://keboola.atlassian.net/browse/PS-117

