### PR TITLE
params.component fix

### DIFF
--- a/src/JobFactory.php
+++ b/src/JobFactory.php
@@ -69,6 +69,12 @@ class JobFactory
 
     public function loadFromExistingJobData(array $data): Job
     {
+        /* For legacy components (e.g. orchestrator), there is no params.component node in elastic. Instead, the
+        component is stored in root. Here we make a copy of component id under params.component to make it
+        compatible with the rest of the jobs. */
+        if (empty($data['params']['component']) && !empty($data['component'])) {
+            $data['params']['component'] = $data['component'];
+        }
         $data = $this->validateJobData($data, FullJobDefinition::class);
         return new Job($this->objectEncryptorFactory, $data);
     }

--- a/src/JobFactory/FullJobDefinition.php
+++ b/src/JobFactory/FullJobDefinition.php
@@ -97,7 +97,7 @@ class FullJobDefinition extends NewJobDefinition
             ->ignoreExtraKeys(false)
             ->children()
                 ->scalarNode('config')->end()
-                ->scalarNode('component')->cannotBeEmpty()->end()
+                ->scalarNode('component')->cannotBeEmpty()->isRequired()->end()
                 ->scalarNode('mode')
                     ->validate()
                         ->ifNotInArray(['run', 'debug'])

--- a/tests/JobFactory/FullJobDefinitionTest.php
+++ b/tests/JobFactory/FullJobDefinitionTest.php
@@ -86,6 +86,7 @@ class FullJobDefinitionTest extends BaseTest
                     'id' => 123456,
                     'name' => 'Test orchestration',
                 ],
+                'component' => 'orchestrator',
                 'initializedBy' => 'trigger',
                 'initiator' => [
                     'id' => 199182,


### PR DESCRIPTION
fix: make params.component node required and always present even for legacy jobs

https://keboola.slack.com/archives/C13CP6YMV/p1578570031000500