### PR TITLE
fix: tolerate special modes used by legacy transformations jobs

### DIFF
--- a/src/JobFactory/FullJobDefinition.php
+++ b/src/JobFactory/FullJobDefinition.php
@@ -106,7 +106,7 @@ class FullJobDefinition extends NewJobDefinition
                     ->validate()
                         ->ifNotInArray(['run', 'debug',
                             // these are only for compatibility with transformation jobs, not used on new jobs
-                            'dry-run', 'prepare', 'input', 'full', 'single'
+                            'dry-run', 'prepare', 'input', 'full', 'single',
                         ])
                         ->thenInvalid(
                             'Mode must be one of "run" or "debug" (or "dry-run","prepare","input","full","single").'

--- a/src/JobFactory/FullJobDefinition.php
+++ b/src/JobFactory/FullJobDefinition.php
@@ -42,6 +42,10 @@ class FullJobDefinition extends NewJobDefinition
                     ->end()
                 ->end()
                 ->arrayNode('process')->ignoreExtraKeys(false)->end()
+                ->scalarNode('isFinished')->end()
+                ->scalarNode('url')->end()
+                ->scalarNode('_index')->end()
+                ->scalarNode('_type')->end()
                 ->append($this->addTokenNode())
                 ->append($this->addProjectNode())
                 ->append($this->addParamsNode())
@@ -100,8 +104,13 @@ class FullJobDefinition extends NewJobDefinition
                 ->scalarNode('component')->cannotBeEmpty()->isRequired()->end()
                 ->scalarNode('mode')
                     ->validate()
-                        ->ifNotInArray(['run', 'debug'])
-                        ->thenInvalid('Mode must be one of "run" or "debug".')
+                        ->ifNotInArray(['run', 'debug',
+                            // these are only for compatibility with transformation jobs, not used on new jobs
+                            'dry-run', 'prepare', 'input', 'full', 'single'
+                        ])
+                        ->thenInvalid(
+                            'Mode must be one of "run" or "debug" (or "dry-run","prepare","input","full","single").'
+                        )
                     ->end()
                 ->end()
                 ->scalarNode('row')->defaultNull()->end()

--- a/tests/JobFactory/FullJobDefinitionTest.php
+++ b/tests/JobFactory/FullJobDefinitionTest.php
@@ -192,7 +192,8 @@ class FullJobDefinitionTest extends BaseTest
                         'mode' => 'invalid',
                     ],
                 ],
-                'Invalid configuration for path "job.params.mode": Mode must be one of "run" or "debug".',
+                'Invalid configuration for path "job.params.mode": Mode must be one of "run" ' .
+                'or "debug" (or "dry-run","prepare","input","full","single").',
             ],
             'Missing params' => [
                 [

--- a/tests/JobFactoryTest.php
+++ b/tests/JobFactoryTest.php
@@ -108,7 +108,7 @@ class JobFactoryTest extends BaseTest
         self::assertEquals('2345.' . $job->getId(), $job->getRunId());
     }
 
-    public function testCreateLegacyJob(): void
+    public function testLoadLegacyOrchestratorJob(): void
     {
         $factory = $this->getJobFactory();
         $data = [
@@ -162,6 +162,55 @@ class JobFactoryTest extends BaseTest
         self::expectException(ClientException::class);
         self::expectExceptionMessage('The child node "component" at path "job.params" must be configured.');
         $this->getJobFactory()->loadFromExistingJobData($jobData);
+    }
+
+    public function testLoadLegacyTransformationsJob(): void
+    {
+        $jobData = [
+            'id' => 138361,
+            'runId' => '138362',
+            'lockName' => 'transformation-21-137869-run',
+            'project' => [
+                'id' => 21,
+                'name' => 'Odin - Queue',
+            ],
+            'token' => [
+                'id' => '127',
+                'description' => 'john.doe@keboola.com',
+                'token' => getenv('TEST_STORAGE_API_TOKEN'),
+            ],
+            'component' => 'transformation',
+            'command' => 'run',
+            'params' => [
+                'call' => 'run',
+                'mode' => 'full',
+                'phases' => [],
+                'transformations' => [],
+                'config' => '137869',
+                'configBucketId' => '137869',
+            ],
+            'result' => [],
+            'status' => 'waiting',
+            'process' => [
+                'host' => 'ip-10-0-41-225.us-east-2.compute.internal',
+                'pid' => 96,
+            ],
+            'createdTime' => '2020-01-17T10:21:14+01:00',
+            'startTime' => null,
+            'endTime' => null,
+            'durationSeconds' => null,
+            'waitSeconds' => null,
+            'nestingLevel' => 0,
+            'isFinished' => false,
+            '_index' => null,
+            '_type' => null,
+            'url' => 'https://queue.east-us-2.azure.keboola.com/jobs/138361',
+        ];
+        $job = $this->getJobFactory()->loadFromExistingJobData($jobData);
+        $jobData['params']['component'] = 'transformation';
+        $jobData['params']['row'] = null;
+        $jobData['params']['tag'] = null;
+        self::assertEquals($jobData, $job->jsonSerialize());
     }
 
     public function testStaticGetters(): void


### PR DESCRIPTION
ty ostatni mody jsou pro sandboxy, pri vytvoreni by to nemelo vadit (posle se v configData, v queue API se to pretransformuje a na transformation API posle v body), ale job s takovymy parametry nejde na nove queue nacist s hlaskou
{
    "errorMessage": "Invalid configuration for path \"job.params.mode\": Mode must be one of \"run\" or \"debug\"."
}