### PR TITLE
API Updates

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,5 +1,6 @@
 pool:
-  vmImage: ubuntu-latest
+  name: 'Default'
+#  vmImage: ubuntu-latest
 
 pr: none
 trigger:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,6 +1,5 @@
 pool:
-  name: 'Default'
-#  vmImage: ubuntu-latest
+  vmImage: ubuntu-latest
 
 pr: none
 trigger:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - internal-api
     networks:
       - internal-api-client
-    command: ["/code/docker/phpunit.sh"]
+    command: ['sh', '-c', '/code/docker/wait-for-it.sh --strict --timeout=120 internal-api:80 -- composer ci']
 
   tests-local:
     <<: *tests
@@ -25,10 +25,10 @@ services:
   internal-api:
     image: keboolapes.azurecr.io/job-queue-internal-api:latest
     ports:
-      - "80:80"
+      - "81:80"
     volumes:
+      # to get wait-for-it
       - ./:/build-code
-      - ./var:/code/var
     environment:
       - log_abs_connection_string=
       - log_abs_container=debug-files
@@ -51,7 +51,7 @@ services:
     image: mysql:8
     command: --default-authentication-plugin=mysql_native_password
     ports:
-      - "3306:3306"
+      - "3307:3306"
     environment:
       - MYSQL_DATABASE=jobs
       - MYSQL_ROOT_PASSWORD=root

--- a/docker/phpunit.sh
+++ b/docker/phpunit.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-set -e
-
-/code/docker/wait-for-it.sh --strict --timeout=120 internal-api:80 mysql:3306
-composer ci

--- a/src/Client.php
+++ b/src/Client.php
@@ -101,7 +101,8 @@ class Client
         return $this->jobFactory->loadFromExistingJobData($result);
     }
 
-    public function getJobsWithProjectId(JobListOptions $listOptions): array {
+    public function listJobs(JobListOptions $listOptions): array
+    {
         $request = new Request('GET', 'jobs/?' . implode('&', $listOptions->getQueryParameters()));
         $result = $this->sendRequest($request);
         return $this->mapJobsFromResponse($result);

--- a/src/Client.php
+++ b/src/Client.php
@@ -101,17 +101,8 @@ class Client
         return $this->jobFactory->loadFromExistingJobData($result);
     }
 
-    public function getJobsWithProjectId(
-        string $projectId,
-        string $query = '',
-        int $offset = 0,
-        int $limit = 100
-    ): array {
-        $pathQuery = sprintf('project.id:%s', $projectId);
-        if (!empty($query)) {
-            $pathQuery .= sprintf(' AND %s', $query);
-        }
-        $request = new Request('GET', sprintf('jobs?query=(%s)&offset=%s&limit=%s', $pathQuery, $offset, $limit));
+    public function getJobsWithProjectId(JobListOptions $listOptions): array {
+        $request = new Request('GET', 'jobs/?' . implode('&', $listOptions->getQueryParameters()));
         $result = $this->sendRequest($request);
         return $this->mapJobsFromResponse($result);
     }
@@ -121,11 +112,10 @@ class Client
         if (!$jobIds) {
             return [];
         }
-        $conditions = array_map(function (string $status): string {
-            return 'id:' . $status;
+        $conditions = array_map(function (string $id): string {
+            return 'id[]=' . urlencode($id);
         }, $jobIds);
-        $query = '(' . implode(' OR ', $conditions) . ')';
-        $request = new Request('GET', 'jobs?query=' . $query);
+        $request = new Request('GET', 'jobs?' . implode('&', $conditions));
         $result = $this->sendRequest($request);
         return $this->mapJobsFromResponse($result);
     }
@@ -136,10 +126,9 @@ class Client
             return [];
         }
         $conditions = array_map(function (string $status): string {
-            return 'status:' . $status;
+            return 'status[]=' . $status;
         }, $statuses);
-        $query = '(' . implode(' OR ', $conditions) . ')';
-        $request = new Request('GET', 'jobs?query=' . $query);
+        $request = new Request('GET', 'jobs?' . implode('&', $conditions));
         $result = $this->sendRequest($request);
         return $this->mapJobsFromResponse($result);
     }

--- a/src/JobFactory/FullJobDefinition.php
+++ b/src/JobFactory/FullJobDefinition.php
@@ -18,8 +18,13 @@ class FullJobDefinition extends NewJobDefinition
         // @formatter:off
         $rootNode
             ->children()
-                ->scalarNode('id')->isRequired()->cannotBeEmpty()->end()
-                ->scalarNode('runId')->end()
+                ->scalarNode('id')
+                    ->isRequired()->cannotBeEmpty()
+                    ->beforeNormalization()->always($this->getStringNormalizer())->end()
+                ->end()
+                ->scalarNode('runId')
+                    ->beforeNormalization()->always($this->getStringNormalizer())->end()
+                ->end()
                 ->scalarNode('lockName')->end()
                 ->scalarNode('component')->end()
                 ->scalarNode('command')->end()
@@ -55,6 +60,17 @@ class FullJobDefinition extends NewJobDefinition
         return $rootNode;
     }
 
+    private function getStringNormalizer(): \Closure
+    {
+        return function ($v) {
+            if (is_scalar($v)) {
+                return empty($v) ? null : (string)$v;
+            } else {
+                return $v;
+            }
+        };
+    }
+
     private function addProjectNode(): NodeDefinition
     {
         $treeBuilder = new TreeBuilder('project');
@@ -64,8 +80,13 @@ class FullJobDefinition extends NewJobDefinition
 
         $node->isRequired()
             ->children()
-                ->scalarNode('id')->isRequired()->cannotBeEmpty()->end()
-                ->scalarNode('name')->end()
+                ->scalarNode('id')
+                    ->isRequired()->cannotBeEmpty()
+                    ->beforeNormalization()->always($this->getStringNormalizer())->end()
+                ->end()
+                ->scalarNode('name')
+                    ->beforeNormalization()->always($this->getStringNormalizer())->end()
+                ->end()
             ->end()
         ->end();
 
@@ -81,9 +102,17 @@ class FullJobDefinition extends NewJobDefinition
 
         $node->isRequired()
             ->children()
-                ->scalarNode('id')->isRequired()->cannotBeEmpty()->end()
-                ->scalarNode('description')->end()
-                ->scalarNode('token')->isRequired()->cannotBeEmpty()->end()
+                ->scalarNode('id')
+                    ->isRequired()->cannotBeEmpty()
+                    ->beforeNormalization()->always($this->getStringNormalizer())->end()
+                ->end()
+                ->scalarNode('description')
+                    ->beforeNormalization()->always($this->getStringNormalizer())->end()
+                ->end()
+                ->scalarNode('token')
+                    ->isRequired()->cannotBeEmpty()
+                    ->beforeNormalization()->always($this->getStringNormalizer())->end()
+                ->end()
             ->end()
         ->end();
 
@@ -100,8 +129,13 @@ class FullJobDefinition extends NewJobDefinition
         $node->isRequired()
             ->ignoreExtraKeys(false)
             ->children()
-                ->scalarNode('config')->end()
-                ->scalarNode('component')->cannotBeEmpty()->isRequired()->end()
+                ->scalarNode('config')
+                    ->beforeNormalization()->always($this->getStringNormalizer())->end()
+                ->end()
+                ->scalarNode('component')
+                    ->cannotBeEmpty()->isRequired()
+                    ->beforeNormalization()->always($this->getStringNormalizer())->end()
+                ->end()
                 ->scalarNode('mode')
                     ->validate()
                         ->ifNotInArray(['run', 'debug',
@@ -113,8 +147,14 @@ class FullJobDefinition extends NewJobDefinition
                         )
                     ->end()
                 ->end()
-                ->scalarNode('row')->defaultNull()->end()
-                ->scalarNode('tag')->defaultNull()->end()
+                ->scalarNode('row')
+                    ->defaultNull()
+                    ->beforeNormalization()->always($this->getStringNormalizer())->end()
+                ->end()
+                ->scalarNode('tag')
+                    ->defaultNull()
+                    ->beforeNormalization()->always($this->getStringNormalizer())->end()
+                ->end()
                 ->arrayNode('configData')->ignoreExtraKeys(false)->end()
             ->end()
         ->end();

--- a/src/JobFactory/FullJobDefinition.php
+++ b/src/JobFactory/FullJobDefinition.php
@@ -64,7 +64,7 @@ class FullJobDefinition extends NewJobDefinition
     {
         return function ($v) {
             if (is_scalar($v)) {
-                return empty($v) ? null : (string)$v;
+                return empty($v) ? null : (string) $v;
             } else {
                 return $v;
             }

--- a/src/JobFactory/Job.php
+++ b/src/JobFactory/Job.php
@@ -26,6 +26,7 @@ class Job implements JsonSerializable
         if (empty($this->data['runId'])) {
             $this->data['runId'] = $this->data['id'];
         }
+        $this->data['isFinished'] = (bool) in_array($this->getStatus(), JobFactory::getFinishedStatuses());
         // it's important to clone here because we change state of the factory!
         // this is tested by JobFactoryTest::testEncryptionMultipleJobs()
         $this->objectEncryptorFactory = clone $objectEncryptorFactory;
@@ -115,7 +116,7 @@ class Job implements JsonSerializable
 
     public function isFinished(): bool
     {
-        return in_array($this->data['status'], JobFactory::getFinishedStatuses());
+        return (bool) $this->data['isFinished'];
     }
 
     public function jsonSerialize(): array

--- a/src/JobFactory/Job.php
+++ b/src/JobFactory/Job.php
@@ -47,16 +47,12 @@ class Job implements JsonSerializable
 
     public function getConfigId(): ?string
     {
-        if (empty($this->data['params']['config'])) {
-            return null;
-        } else {
-            return (string) $this->data['params']['config'];
-        }
+        return $this->data['params']['config'] ?? null;
     }
 
     public function getId(): string
     {
-        return (string) $this->data['id'];
+        return $this->data['id'];
     }
 
     public function getMode(): string
@@ -66,7 +62,7 @@ class Job implements JsonSerializable
 
     public function getProjectId(): string
     {
-        return (string) $this->data['project']['id'];
+        return $this->data['project']['id'];
     }
 
     public function getResult(): array
@@ -76,11 +72,7 @@ class Job implements JsonSerializable
 
     public function getRowId(): ?string
     {
-        if (empty($this->data['params']['row'])) {
-            return null;
-        } else {
-            return (string) $this->data['params']['row'];
-        }
+        return $this->data['params']['row'] ?? null;
     }
 
     public function getStatus(): string
@@ -90,11 +82,7 @@ class Job implements JsonSerializable
 
     public function getTag(): ?string
     {
-        if (empty($this->data['params']['tag'])) {
-            return null;
-        } else {
-            return (string) $this->data['params']['tag'];
-        }
+        return $this->data['params']['tag'] ?? null;
     }
 
     public function getToken(): string
@@ -111,7 +99,7 @@ class Job implements JsonSerializable
 
     public function getRunId(): string
     {
-        return (string) $this->data['runId'];
+        return $this->data['runId'];
     }
 
     public function isFinished(): bool

--- a/src/JobListOptions.php
+++ b/src/JobListOptions.php
@@ -48,10 +48,6 @@ class JobListOptions
     /** @var int */
     private $limit = 100;
 
-    public function __construct()
-    {
-    }
-
     public function getQueryParameters(): array
     {
         $arrayableProps = ['ids' => 'id', 'components' => 'component', 'configs' => 'config', 'modes' => 'mode',
@@ -75,9 +71,6 @@ class JobListOptions
         return $parameters;
     }
 
-    /**
-     * @return array
-     */
     public function getIds(): array
     {
         return $this->ids;
@@ -89,9 +82,6 @@ class JobListOptions
         return $this;
     }
 
-    /**
-     * @return array
-     */
     public function getComponents(): array
     {
         return $this->components;
@@ -103,9 +93,6 @@ class JobListOptions
         return $this;
     }
 
-    /**
-     * @return array
-     */
     public function getConfigs(): array
     {
         return $this->configs;
@@ -117,9 +104,6 @@ class JobListOptions
         return $this;
     }
 
-    /**
-     * @return array
-     */
     public function getModes(): array
     {
         return $this->modes;
@@ -131,9 +115,6 @@ class JobListOptions
         return $this;
     }
 
-    /**
-     * @return array
-     */
     public function getProjects(): array
     {
         return $this->projects;
@@ -145,9 +126,6 @@ class JobListOptions
         return $this;
     }
 
-    /**
-     * @return array
-     */
     public function getStatuses(): array
     {
         return $this->statuses;
@@ -159,9 +137,6 @@ class JobListOptions
         return $this;
     }
 
-    /**
-     * @return string
-     */
     public function getStartTimeFrom(): string
     {
         return $this->startTimeFrom;
@@ -173,37 +148,28 @@ class JobListOptions
         return $this;
     }
 
-    /**
-     * @return int
-     */
     public function getOffset(): int
     {
         return $this->offset;
     }
 
-    public function setOffset(string $value): JobListOptions
+    public function setOffset(int $value): JobListOptions
     {
         $this->offset = $value;
         return $this;
     }
 
-    /**
-     * @return int
-     */
     public function getLimit(): int
     {
         return $this->limit;
     }
 
-    public function setLimit(string $value): JobListOptions
+    public function setLimit(int $value): JobListOptions
     {
         $this->limit = $value;
         return $this;
     }
 
-    /**
-     * @return string
-     */
     public function getCreatedTimeFrom(): string
     {
         return $this->createdTimeFrom;
@@ -215,9 +181,6 @@ class JobListOptions
         return $this;
     }
 
-    /**
-     * @return string
-     */
     public function getEndTimeTo(): string
     {
         return $this->endTimeTo;
@@ -229,9 +192,6 @@ class JobListOptions
         return $this;
     }
 
-    /**
-     * @return string
-     */
     public function getEndTimeFrom(): string
     {
         return $this->endTimeFrom;
@@ -243,9 +203,6 @@ class JobListOptions
         return $this;
     }
 
-    /**
-     * @return string
-     */
     public function getStartTimeTo(): string
     {
         return $this->startTimeTo;
@@ -257,9 +214,6 @@ class JobListOptions
         return $this;
     }
 
-    /**
-     * @return string
-     */
     public function getCreatedTimeTo(): string
     {
         return $this->createdTimeTo;

--- a/src/JobListOptions.php
+++ b/src/JobListOptions.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Keboola\JobQueueInternalClient;
 
-use Keboola\JobQueueInternalClient\JobFactory\Job;
-
 class JobListOptions
 {
     /** @var array */
@@ -54,90 +52,6 @@ class JobListOptions
     {
     }
 
-    public function setIds(array $values): JobListOptions
-    {
-        $this->ids = $values;
-        return $this;
-    }
-
-    public function setComponents(array $values): JobListOptions
-    {
-        $this->components = $values;
-        return $this;
-    }
-
-    public function setConfigs(array $values): JobListOptions
-    {
-        $this->configs = $values;
-        return $this;
-    }
-
-    public function setModes(array $values): JobListOptions
-    {
-        $this->modes = $values;
-        return $this;
-    }
-
-    public function setProjects(array $values): JobListOptions
-    {
-        $this->projects = $values;
-        return $this;
-    }
-
-    public function setStatuses(array $values): JobListOptions
-    {
-        $this->statuses = $values;
-        return $this;
-    }
-
-    public function setStartTimeFrom(string $value): JobListOptions
-    {
-        $this->startTimeFrom = $value;
-        return $this;
-    }
-
-    public function setStartTimeTo(string $value): JobListOptions
-    {
-        $this->startTimeTo = $value;
-        return $this;
-    }
-
-    public function setCreatedTimeFrom(string $value): JobListOptions
-    {
-        $this->createdTimeFrom = $value;
-        return $this;
-    }
-
-    public function setCreatedTimeTo(string $value): JobListOptions
-    {
-        $this->createdTimeTo = $value;
-        return $this;
-    }
-
-    public function setEndTimeFrom(string $value): JobListOptions
-    {
-        $this->endTimeFrom = $value;
-        return $this;
-    }
-
-    public function setEndTimeTo(string $value): JobListOptions
-    {
-        $this->endTimeTo = $value;
-        return $this;
-    }
-
-    public function setOffset(string $value): JobListOptions
-    {
-        $this->offset = $value;
-        return $this;
-    }
-
-    public function setLimit(string $value): JobListOptions
-    {
-        $this->limit = $value;
-        return $this;
-    }
-
     public function getQueryParameters(): array
     {
         $arrayableProps = ['ids' => 'id', 'components' => 'component', 'configs' => 'config', 'modes' => 'mode',
@@ -159,5 +73,201 @@ class JobListOptions
             }
         }
         return $parameters;
+    }
+
+    /**
+     * @return array
+     */
+    public function getIds(): array
+    {
+        return $this->ids;
+    }
+
+    public function setIds(array $values): JobListOptions
+    {
+        $this->ids = $values;
+        return $this;
+    }
+
+    /**
+     * @return array
+     */
+    public function getComponents(): array
+    {
+        return $this->components;
+    }
+
+    public function setComponents(array $values): JobListOptions
+    {
+        $this->components = $values;
+        return $this;
+    }
+
+    /**
+     * @return array
+     */
+    public function getConfigs(): array
+    {
+        return $this->configs;
+    }
+
+    public function setConfigs(array $values): JobListOptions
+    {
+        $this->configs = $values;
+        return $this;
+    }
+
+    /**
+     * @return array
+     */
+    public function getModes(): array
+    {
+        return $this->modes;
+    }
+
+    public function setModes(array $values): JobListOptions
+    {
+        $this->modes = $values;
+        return $this;
+    }
+
+    /**
+     * @return array
+     */
+    public function getProjects(): array
+    {
+        return $this->projects;
+    }
+
+    public function setProjects(array $values): JobListOptions
+    {
+        $this->projects = $values;
+        return $this;
+    }
+
+    /**
+     * @return array
+     */
+    public function getStatuses(): array
+    {
+        return $this->statuses;
+    }
+
+    public function setStatuses(array $values): JobListOptions
+    {
+        $this->statuses = $values;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getStartTimeFrom(): string
+    {
+        return $this->startTimeFrom;
+    }
+
+    public function setStartTimeFrom(string $value): JobListOptions
+    {
+        $this->startTimeFrom = $value;
+        return $this;
+    }
+
+    /**
+     * @return int
+     */
+    public function getOffset(): int
+    {
+        return $this->offset;
+    }
+
+    public function setOffset(string $value): JobListOptions
+    {
+        $this->offset = $value;
+        return $this;
+    }
+
+    /**
+     * @return int
+     */
+    public function getLimit(): int
+    {
+        return $this->limit;
+    }
+
+    public function setLimit(string $value): JobListOptions
+    {
+        $this->limit = $value;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCreatedTimeFrom(): string
+    {
+        return $this->createdTimeFrom;
+    }
+
+    public function setCreatedTimeFrom(string $value): JobListOptions
+    {
+        $this->createdTimeFrom = $value;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getEndTimeTo(): string
+    {
+        return $this->endTimeTo;
+    }
+
+    public function setEndTimeTo(string $value): JobListOptions
+    {
+        $this->endTimeTo = $value;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getEndTimeFrom(): string
+    {
+        return $this->endTimeFrom;
+    }
+
+    public function setEndTimeFrom(string $value): JobListOptions
+    {
+        $this->endTimeFrom = $value;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getStartTimeTo(): string
+    {
+        return $this->startTimeTo;
+    }
+
+    public function setStartTimeTo(string $value): JobListOptions
+    {
+        $this->startTimeTo = $value;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCreatedTimeTo(): string
+    {
+        return $this->createdTimeTo;
+    }
+
+    public function setCreatedTimeTo(string $value): JobListOptions
+    {
+        $this->createdTimeTo = $value;
+        return $this;
     }
 }

--- a/src/JobListOptions.php
+++ b/src/JobListOptions.php
@@ -1,0 +1,163 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\JobQueueInternalClient;
+
+use Keboola\JobQueueInternalClient\JobFactory\Job;
+
+class JobListOptions
+{
+    /** @var array */
+    private $ids;
+
+    /** @var array */
+    private $components;
+
+    /** @var array */
+    private $configs;
+
+    /** @var array */
+    private $modes;
+
+    /** @var array */
+    private $projects;
+
+    /** @var array */
+    private $statuses;
+
+    /** @var string */
+    private $startTimeFrom;
+
+    /** @var string */
+    private $startTimeTo;
+
+    /** @var string */
+    private $createdTimeFrom;
+
+    /** @var string */
+    private $createdTimeTo;
+
+    /** @var string */
+    private $endTimeFrom;
+
+    /** @var string */
+    private $endTimeTo;
+
+    /** @var int */
+    private $offset = 0;
+
+    /** @var int */
+    private $limit = 100;
+
+    public function __construct()
+    {
+    }
+
+    public function setIds(array $values): JobListOptions
+    {
+        $this->ids = $values;
+        return $this;
+    }
+
+    public function setComponents(array $values): JobListOptions
+    {
+        $this->components = $values;
+        return $this;
+    }
+
+    public function setConfigs(array $values): JobListOptions
+    {
+        $this->configs = $values;
+        return $this;
+    }
+
+    public function setModes(array $values): JobListOptions
+    {
+        $this->modes = $values;
+        return $this;
+    }
+
+    public function setProjects(array $values): JobListOptions
+    {
+        $this->projects = $values;
+        return $this;
+    }
+
+    public function setStatuses(array $values): JobListOptions
+    {
+        $this->statuses = $values;
+        return $this;
+    }
+
+    public function setStartTimeFrom(string $value): JobListOptions
+    {
+        $this->startTimeFrom = $value;
+        return $this;
+    }
+
+    public function setStartTimeTo(string $value): JobListOptions
+    {
+        $this->startTimeTo = $value;
+        return $this;
+    }
+
+    public function setCreatedTimeFrom(string $value): JobListOptions
+    {
+        $this->createdTimeFrom = $value;
+        return $this;
+    }
+
+    public function setCreatedTimeTo(string $value): JobListOptions
+    {
+        $this->createdTimeTo = $value;
+        return $this;
+    }
+
+    public function setEndTimeFrom(string $value): JobListOptions
+    {
+        $this->endTimeFrom = $value;
+        return $this;
+    }
+
+    public function setEndTimeTo(string $value): JobListOptions
+    {
+        $this->endTimeTo = $value;
+        return $this;
+    }
+
+    public function setOffset(string $value): JobListOptions
+    {
+        $this->offset = $value;
+        return $this;
+    }
+
+    public function setLimit(string $value): JobListOptions
+    {
+        $this->limit = $value;
+        return $this;
+    }
+
+    public function getQueryParameters(): array
+    {
+        $arrayableProps = ['ids' => 'id', 'components' => 'component', 'configs' => 'config', 'modes' => 'mode',
+            'projects' => 'project', 'statuses' => 'status'];
+        $scalarProps = ['startTimeFrom' => 'startTimeFrom', 'startTimeTo' => 'startTimeTo',
+            'createdTimeFrom' => 'createdTimeFrom', 'createdTimeTo' => 'createdTimeTo', 'endTimeFrom' => 'endTimeFrom',
+            'endTimeTo' => 'endTimeTo', 'offset' => 'offset', 'limit' => 'limit'];
+        $parameters = [];
+        foreach ($arrayableProps as $propName => $paramName) {
+            if (!empty($this->$propName)) {
+                foreach ($this->$propName as $value) {
+                    $parameters[] = $paramName . '[]=' . urlencode($value);
+                }
+            }
+        }
+        foreach ($scalarProps as $propName => $paramName) {
+            if (!empty($this->$propName)) {
+                $parameters[] = $paramName . '=' . urlencode((string) $this->$propName);
+            }
+        }
+        return $parameters;
+    }
+}

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -458,7 +458,7 @@ class ClientTest extends BaseTest
         $stack->push($history);
         $logger = new TestLogger();
         $client = $this->getClient(['handler' => $stack], $logger);
-        $jobs = $client->getJobsWithProjectId((new JobListOptions())->setProjects(['456']));
+        $jobs = $client->listJobs((new JobListOptions())->setProjects(['456']));
 
         self::assertCount(1, $jobs);
         /** @var Job $job */
@@ -479,7 +479,7 @@ class ClientTest extends BaseTest
                 '[{
                     "id": "123",
                     "project": {
-                        "id": "456"
+                        "id": "šěřč!@#%^$&"
                     },
                     "token": {
                         "id": "789",
@@ -501,15 +501,21 @@ class ClientTest extends BaseTest
         $stack->push($history);
         $logger = new TestLogger();
         $client = $this->getClient(['handler' => $stack], $logger);
-        $jobs = $client->getJobsWithProjectId((new JobListOptions())->setProjects(['456']));
+        $jobs = $client->listJobs(
+            (new JobListOptions())->setProjects(['šěřč!@#%^$&'])->setComponents(['th!$ |& n°t valid'])
+        );
 
         self::assertCount(1, $jobs);
         /** @var Job $job */
         $job = $jobs[0];
         self::assertEquals('123', $job->getId());
-        self::assertEquals('456', $job->getProjectId());
+        self::assertEquals('šěřč!@#%^$&', $job->getProjectId());
 
         $request = $mock->getLastRequest();
-        self::assertEquals('project%5B%5D=456&limit=100', $request->getUri()->getQuery());
+        self::assertEquals(
+            'component%5B%5D=th%21%24+%7C%26+n%C2%B0t+valid&' .
+                'project%5B%5D=%C5%A1%C4%9B%C5%99%C4%8D%21%40%23%25%5E%24%26&limit=100',
+            $request->getUri()->getQuery()
+        );
     }
 }

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -13,6 +13,7 @@ use Keboola\JobQueueInternalClient\Client;
 use Keboola\JobQueueInternalClient\ClientException;
 use Keboola\JobQueueInternalClient\JobFactory;
 use Keboola\JobQueueInternalClient\JobFactory\Job;
+use Keboola\JobQueueInternalClient\JobListOptions;
 use Keboola\ObjectEncryptor\ObjectEncryptorFactory;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
@@ -457,7 +458,7 @@ class ClientTest extends BaseTest
         $stack->push($history);
         $logger = new TestLogger();
         $client = $this->getClient(['handler' => $stack], $logger);
-        $jobs = $client->getJobsWithProjectId('456');
+        $jobs = $client->getJobsWithProjectId((new JobListOptions())->setProjects(['456']));
 
         self::assertCount(1, $jobs);
         /** @var Job $job */

--- a/tests/JobFactory/JobTest.php
+++ b/tests/JobFactory/JobTest.php
@@ -171,6 +171,7 @@ class JobTest extends BaseTest
     {
         $expected = $this->jobData;
         $expected['runId'] = '123456456';
+        $expected['isFinished'] = false;
         self::assertEquals($expected, $this->getJob()->jsonSerialize());
     }
 

--- a/tests/JobFactory/JobTest.php
+++ b/tests/JobFactory/JobTest.php
@@ -50,10 +50,6 @@ class JobTest extends BaseTest
     {
         self::assertEquals('454124290', $this->getJob()->getConfigId());
 
-        $jobDataWithConfigIdInt = $this->jobData;
-        $jobDataWithConfigIdInt['params']['config'] = 123456789;
-        self::assertSame('123456789', $this->getJob($jobDataWithConfigIdInt)->getConfigId());
-
         $jobDataWithoutConfigId = $this->jobData;
         unset($jobDataWithoutConfigId['params']['config']);
         self::assertNull($this->getJob($jobDataWithoutConfigId)->getConfigId());
@@ -71,10 +67,6 @@ class JobTest extends BaseTest
         $jobData = $this->jobData;
         $jobData['runId'] = '1234.567';
         self::assertSame('1234', $this->getJob($jobData)->getParentRunId());
-
-        $jobData = $this->jobData;
-        $jobData['runId'] = 1234.567;
-        self::assertSame('1234', $this->getJob($jobData)->getParentRunId());
     }
 
     public function testGetRunId(): void
@@ -83,10 +75,6 @@ class JobTest extends BaseTest
 
         $jobData = $this->jobData;
         $jobData['runId'] = '1234.567';
-        self::assertEquals('1234.567', $this->getJob($jobData)->getRunId());
-
-        $jobData = $this->jobData;
-        $jobData['runId'] = 1234.567;
         self::assertEquals('1234.567', $this->getJob($jobData)->getRunId());
     }
 
@@ -109,13 +97,9 @@ class JobTest extends BaseTest
     {
         self::assertNull($this->getJob()->getRowId());
 
-        $jobDataWithRowIdInt = $this->jobData;
-        $jobDataWithRowIdInt['params']['row'] = 123456789;
-        self::assertSame('123456789', $this->getJob($jobDataWithRowIdInt)->getRowId());
-
-        $jobDataWithoutRowId = $this->jobData;
-        unset($jobDataWithoutRowId['params']['row']);
-        self::assertNull($this->getJob($jobDataWithoutRowId)->getRowId());
+        $jobDataWithRowId = $this->jobData;
+        $jobDataWithRowId['params']['row'] = '123456789';
+        self::assertSame('123456789', $this->getJob($jobDataWithRowId)->getRowId());
     }
 
     public function testGetStatus(): void
@@ -127,13 +111,9 @@ class JobTest extends BaseTest
     {
         self::assertNull($this->getJob()->getTag());
 
-        $jobDataWithTagNumeric = $this->jobData;
-        $jobDataWithTagNumeric['params']['tag'] = 1.1;
-        self::assertSame('1.1', $this->getJob($jobDataWithTagNumeric)->getTag());
-
-        $jobDataWithoutTag = $this->jobData;
-        unset($jobDataWithoutTag['params']['tag']);
-        self::assertNull($this->getJob($jobDataWithoutTag)->getTag());
+        $jobDataWithTag = $this->jobData;
+        $jobDataWithTag['params']['tag'] = '1.1';
+        self::assertSame('1.1', $this->getJob($jobDataWithTag)->getTag());
     }
 
     public function testGetToken(): void

--- a/tests/JobFactoryTest.php
+++ b/tests/JobFactoryTest.php
@@ -82,7 +82,7 @@ class JobFactoryTest extends BaseTest
         self::assertSame('123', $job->getConfigId());
         self::assertSame('123', $job->getRowId());
         self::assertSame('123', $job->getTag());
-        self::assertSame('1234.567.' . $job->getId() , $job->getRunId());
+        self::assertSame('1234.567.' . $job->getId(), $job->getRunId());
         self::assertSame('1234.567', $job->getParentRunId());
         self::assertSame('123', $job->jsonSerialize()['params']['config']);
         self::assertSame('123', $job->jsonSerialize()['params']['row']);

--- a/tests/JobFactoryTest.php
+++ b/tests/JobFactoryTest.php
@@ -61,6 +61,35 @@ class JobFactoryTest extends BaseTest
         self::assertEquals($job->getId(), $job->getRunId());
     }
 
+    public function testCreateNewJobNormalize(): void
+    {
+        $factory = $this->getJobFactory();
+        $data = [
+            'token' => getenv('TEST_STORAGE_API_TOKEN'),
+            'config' => 123,
+            'component' => 123,
+            'mode' => 'run',
+            'tag' => 123,
+            'row' => 123,
+            'parentRunId' => 1234.567,
+        ];
+        $job = $factory->createNewJob($data);
+        self::assertNotEmpty($job->getId());
+        self::assertStringStartsWith('KBC::ProjectSecure::', $job->getToken());
+        self::assertSame([], $job->getConfigData());
+        self::assertSame(getenv('TEST_STORAGE_API_TOKEN'), $job->getTokenDecrypted());
+        self::assertSame([], $job->getConfigDataDecrypted());
+        self::assertSame('123', $job->getConfigId());
+        self::assertSame('123', $job->getRowId());
+        self::assertSame('123', $job->getTag());
+        self::assertSame('1234.567.' . $job->getId() , $job->getRunId());
+        self::assertSame('1234.567', $job->getParentRunId());
+        self::assertSame('123', $job->jsonSerialize()['params']['config']);
+        self::assertSame('123', $job->jsonSerialize()['params']['row']);
+        self::assertSame('123', $job->jsonSerialize()['params']['tag']);
+        self::assertSame('1234.567.' . $job->getId(), $job->jsonSerialize()['runId']);
+    }
+
     public function testGetTokenLegacyDecrypted(): void
     {
         $factory = $this->getJobFactory();


### PR DESCRIPTION
https://keboola.atlassian.net/browse/PS-982

Nejvyznamnejsi zmena je v tom ze jsem metodu `getJobsWithProjectId` nahradil metodou `listJobs`, ktera prijima `JobListOptions` pro filtrovani seznamu jobu. Puvodne se tam posiala elastic query, ktera sla do haje a je nahrazena individualnima filtrama.

Souvisi to jeste s jednou zmenou API, ktera je tady https://github.com/keboola/job-queue-internal-api/pull/7 protoze je tam potreba posilat vic hodnot - demon listuje joby se zadanym stavy nebo joby se zadanymi IDcky - napr. https://github.com/keboola/job-queue-daemon/blob/e4f5627e65c37328b80fecea6888cac7f2521143/src/Daemon.php#L256 a https://github.com/keboola/job-queue-daemon/blob/e4f5627e65c37328b80fecea6888cac7f2521143/src/Daemon.php#L79

Dalsi zmena je zmena normalizace stringu, tzn. aby se z `config: 123` stalo `config: "123"`. Puvodne se to delalo v geterech jobu a to jsem presunul do FullJobDefinition, aby uz to bylo spravne v job data (ktery vraci serializace). To je kvuli tomu, ze MySQL je na to pri hledani citlivy (search na `123` nevrati zaznamy ve kterych je `"123"`), tak jsem to prehodil, aby se to ukladalo konzistentne.

Soucasne s tim je tam pridany isFinished https://keboola.atlassian.net/browse/PS-981