### PR TITLE
PS-1360: new job structure

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,7 +23,6 @@ steps:
     docker-compose down
     docker-compose build --pull
     docker-compose pull
-    docker images --digests
   displayName: 'Build Tests'
 
 - script: docker-compose run --rm tests

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,6 +23,7 @@ steps:
     docker-compose down
     docker-compose build --pull
     docker-compose pull
+    docker images --digests
   displayName: 'Build Tests'
 
 - script: docker-compose run --rm tests

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -2,3 +2,9 @@ parameters:
     checkMissingIterableValueType: false
     ignoreErrors:
         - '#Cannot call method scalarNode\(\) on Symfony\\Component\\Config\\Definition\\Builder\\NodeParentInterface\|null\.#'
+        -
+            message: '#Unreachable statement \- code above always terminates\.#'
+            path: tests/JobFactory/FullJobDefinitionTest.php
+        -
+            message: '#Unreachable statement \- code above always terminates\.#'
+            path:  tests/JobFactoryTest.php

--- a/src/Client.php
+++ b/src/Client.php
@@ -103,7 +103,7 @@ class Client
 
     public function listJobs(JobListOptions $listOptions): array
     {
-        $request = new Request('GET', 'jobs/?' . implode('&', $listOptions->getQueryParameters()));
+        $request = new Request('GET', 'jobs?' . implode('&', $listOptions->getQueryParameters()));
         $result = $this->sendRequest($request);
         return $this->mapJobsFromResponse($result);
     }

--- a/src/JobFactory.php
+++ b/src/JobFactory.php
@@ -143,7 +143,7 @@ class JobFactory
             'tag' => $data['tag'] ?? null,
             'result' => [],
             'usageData' => [],
-            'isFinished' => false
+            'isFinished' => false,
         ];
     }
 }

--- a/src/JobFactory.php
+++ b/src/JobFactory.php
@@ -104,7 +104,7 @@ class JobFactory
     private function initializeNewJobData(array $data): array
     {
         try {
-            $client = $this->storageClientFactory->getClient($data['token']);
+            $client = $this->storageClientFactory->getClient($data['tokenString']);
             $tokenInfo = $client->verifyToken();
             $jobId = $client->generateId();
             $runId = empty($data['parentRunId']) ? $jobId : $data['parentRunId'] . Job::RUN_ID_DELIMITER . $jobId;
@@ -116,12 +116,12 @@ class JobFactory
             );
         }
         $this->objectEncryptorFactory->setProjectId($tokenInfo['owner']['id']);
-        $this->objectEncryptorFactory->setComponentId($data['component']);
+        $this->objectEncryptorFactory->setComponentId($data['componentId']);
         $this->objectEncryptorFactory->setStackId(
             (string) parse_url($this->storageClientFactory->getStorageApiUrl(), PHP_URL_HOST)
         );
         $encryptedToken = $this->objectEncryptorFactory->getEncryptor()->encrypt(
-            $data['token'],
+            $data['tokenString'],
             ProjectWrapper::class
         );
 
@@ -136,10 +136,10 @@ class JobFactory
             'status' => self::STATUS_CREATED,
             'desiredStatus' => self::DESIRED_STATUS_PROCESSING,
             'mode' => $data['mode'],
-            'component' => $data['component'],
-            'configId' => $data['config'] ?? null,
+            'componentId' => $data['componentId'],
+            'configId' => $data['configId'] ?? null,
             'configData' => $data['configData'] ?? null, //@todo encrypt configData?
-            'configRowId' => $data['row'] ?? null,
+            'configRowId' => $data['configRowId'] ?? null,
             'tag' => $data['tag'] ?? null,
             'result' => [],
             'usageData' => [],

--- a/src/JobFactory/FullJobDefinition.php
+++ b/src/JobFactory/FullJobDefinition.php
@@ -43,7 +43,7 @@ class FullJobDefinition extends NewJobDefinition
                     ->isRequired()->cannotBeEmpty()
                     ->beforeNormalization()->always($this->getStringNormalizer())->end()
                 ->end()
-                ->scalarNode('component')
+                ->scalarNode('componentId')
                     ->cannotBeEmpty()->isRequired()
                     ->beforeNormalization()->always($this->getStringNormalizer())->end()
                 ->end()

--- a/src/JobFactory/FullJobDefinition.php
+++ b/src/JobFactory/FullJobDefinition.php
@@ -25,35 +25,73 @@ class FullJobDefinition extends NewJobDefinition
                 ->scalarNode('runId')
                     ->beforeNormalization()->always($this->getStringNormalizer())->end()
                 ->end()
-                ->scalarNode('lockName')->end()
-                ->scalarNode('component')->end()
-                ->scalarNode('command')->end()
-                ->arrayNode('result')->ignoreExtraKeys(false)->end()
+                ->scalarNode('projectId')
+                    ->isRequired()->cannotBeEmpty()
+                    ->beforeNormalization()->always($this->getStringNormalizer())->end()
+                ->end()
+                ->scalarNode('projectName')
+                    ->beforeNormalization()->always($this->getStringNormalizer())->end()
+                ->end()
+                ->scalarNode('tokenId')
+                    ->isRequired()->cannotBeEmpty()
+                    ->beforeNormalization()->always($this->getStringNormalizer())->end()
+                ->end()
+                ->scalarNode('tokenDescription')
+                    ->beforeNormalization()->always($this->getStringNormalizer())->end()
+                ->end()
+                ->scalarNode('tokenString')
+                    ->isRequired()->cannotBeEmpty()
+                    ->beforeNormalization()->always($this->getStringNormalizer())->end()
+                ->end()
+                ->scalarNode('component')
+                    ->cannotBeEmpty()->isRequired()
+                    ->beforeNormalization()->always($this->getStringNormalizer())->end()
+                ->end()
+                ->scalarNode('configId')
+                    ->beforeNormalization()->always($this->getStringNormalizer())->end()
+                ->end()
+                ->scalarNode('mode')
+                    ->validate()
+                        ->ifNotInArray(['run', 'debug',
+                            // these are only for compatibility with transformation jobs, not used on new jobs
+                            'dry-run', 'prepare', 'input', 'full', 'single',
+                        ])
+                        ->thenInvalid(
+                            'Mode must be one of "run" or "debug" (or "dry-run","prepare","input","full","single").'
+                        )
+                    ->end()
+                ->end()
+                ->scalarNode('configRowId')
+                    ->defaultNull()
+                    ->beforeNormalization()->always($this->getStringNormalizer())->end()
+                ->end()
+                ->scalarNode('tag')
+                    ->defaultNull()
+                    ->beforeNormalization()->always($this->getStringNormalizer())->end()
+                ->end()
+                ->arrayNode('configData')->ignoreExtraKeys(false)->end()
                 ->scalarNode('createdTime')->end()
                 ->scalarNode('startTime')->end()
                 ->scalarNode('endTime')->end()
                 ->scalarNode('durationSeconds')->end()
-                ->scalarNode('waitSeconds')->end()
-                ->scalarNode('nestingLevel')->end()
-                ->scalarNode('error')->end()
-                ->scalarNode('errorNote')->end()
-                ->scalarNode('encrypted')->end()
-                ->arrayNode('terminatedBy')->ignoreExtraKeys(false)->end()
-                ->arrayNode('usage')->ignoreExtraKeys(false)->end()
+                ->arrayNode('result')->ignoreExtraKeys(false)->end()
+                ->arrayNode('usageData')->ignoreExtraKeys(false)->end()
                 ->scalarNode('status')->isRequired()
                     ->validate()
                         ->ifNotInArray(JobFactory::getAllStatuses())
                         ->thenInvalid('Status must be one of ' . implode(', ', JobFactory::getAllStatuses()) . '.')
                     ->end()
                 ->end()
-                ->arrayNode('process')->ignoreExtraKeys(false)->end()
-                ->scalarNode('isFinished')->end()
+                ->scalarNode('desiredStatus')->isRequired()
+                    ->validate()
+                        ->ifNotInArray(JobFactory::getAllStatuses())
+                        ->thenInvalid('Status must be one of ' . implode(', ', JobFactory::getAllStatuses()) . '.')
+                    ->end()
+                ->end()
+                ->scalarNode('isFinished')
+                    ->defaultFalse()
+                ->end()
                 ->scalarNode('url')->end()
-                ->scalarNode('_index')->end()
-                ->scalarNode('_type')->end()
-                ->append($this->addTokenNode())
-                ->append($this->addProjectNode())
-                ->append($this->addParamsNode())
             ->end();
         // @formatter:on
 
@@ -69,96 +107,5 @@ class FullJobDefinition extends NewJobDefinition
                 return $v;
             }
         };
-    }
-
-    private function addProjectNode(): NodeDefinition
-    {
-        $treeBuilder = new TreeBuilder('project');
-
-        /** @var ArrayNodeDefinition $node */
-        $node = $treeBuilder->getRootNode();
-
-        $node->isRequired()
-            ->children()
-                ->scalarNode('id')
-                    ->isRequired()->cannotBeEmpty()
-                    ->beforeNormalization()->always($this->getStringNormalizer())->end()
-                ->end()
-                ->scalarNode('name')
-                    ->beforeNormalization()->always($this->getStringNormalizer())->end()
-                ->end()
-            ->end()
-        ->end();
-
-        return $node;
-    }
-
-    private function addTokenNode(): NodeDefinition
-    {
-        $treeBuilder = new TreeBuilder('token');
-
-        /** @var ArrayNodeDefinition $node */
-        $node = $treeBuilder->getRootNode();
-
-        $node->isRequired()
-            ->children()
-                ->scalarNode('id')
-                    ->isRequired()->cannotBeEmpty()
-                    ->beforeNormalization()->always($this->getStringNormalizer())->end()
-                ->end()
-                ->scalarNode('description')
-                    ->beforeNormalization()->always($this->getStringNormalizer())->end()
-                ->end()
-                ->scalarNode('token')
-                    ->isRequired()->cannotBeEmpty()
-                    ->beforeNormalization()->always($this->getStringNormalizer())->end()
-                ->end()
-            ->end()
-        ->end();
-
-        return $node;
-    }
-
-    private function addParamsNode(): NodeDefinition
-    {
-        $treeBuilder = new TreeBuilder('params');
-
-        /** @var ArrayNodeDefinition $node */
-        $node = $treeBuilder->getRootNode();
-
-        $node->isRequired()
-            ->ignoreExtraKeys(false)
-            ->children()
-                ->scalarNode('config')
-                    ->beforeNormalization()->always($this->getStringNormalizer())->end()
-                ->end()
-                ->scalarNode('component')
-                    ->cannotBeEmpty()->isRequired()
-                    ->beforeNormalization()->always($this->getStringNormalizer())->end()
-                ->end()
-                ->scalarNode('mode')
-                    ->validate()
-                        ->ifNotInArray(['run', 'debug',
-                            // these are only for compatibility with transformation jobs, not used on new jobs
-                            'dry-run', 'prepare', 'input', 'full', 'single',
-                        ])
-                        ->thenInvalid(
-                            'Mode must be one of "run" or "debug" (or "dry-run","prepare","input","full","single").'
-                        )
-                    ->end()
-                ->end()
-                ->scalarNode('row')
-                    ->defaultNull()
-                    ->beforeNormalization()->always($this->getStringNormalizer())->end()
-                ->end()
-                ->scalarNode('tag')
-                    ->defaultNull()
-                    ->beforeNormalization()->always($this->getStringNormalizer())->end()
-                ->end()
-                ->arrayNode('configData')->ignoreExtraKeys(false)->end()
-            ->end()
-        ->end();
-
-        return $node;
     }
 }

--- a/src/JobFactory/Job.php
+++ b/src/JobFactory/Job.php
@@ -35,34 +35,39 @@ class Job implements JsonSerializable
         $this->objectEncryptorFactory->setConfigurationId($this->getConfigId());
     }
 
-    public function getComponentId(): string
-    {
-        return $this->data['params']['component'] ?? '';
-    }
-
-    public function getConfigData(): array
-    {
-        return $this->data['params']['configData'] ?? [];
-    }
-
-    public function getConfigId(): ?string
-    {
-        return $this->data['params']['config'] ?? null;
-    }
-
     public function getId(): string
     {
         return $this->data['id'];
     }
 
+    public function getComponentId(): string
+    {
+        return $this->data['component'] ?? '';
+    }
+
+    public function getConfigData(): array
+    {
+        return $this->data['configData'] ?? [];
+    }
+
+    public function getConfigId(): ?string
+    {
+        return $this->data['configId'] ?? null;
+    }
+
     public function getMode(): string
     {
-        return $this->data['params']['mode'];
+        return $this->data['mode'];
     }
 
     public function getProjectId(): string
     {
-        return $this->data['project']['id'];
+        return $this->data['projectId'];
+    }
+
+    public function getProjectName(): string
+    {
+        return $this->data['projectName'];
     }
 
     public function getResult(): array
@@ -70,9 +75,9 @@ class Job implements JsonSerializable
         return $this->data['result'] ?? [];
     }
 
-    public function getRowId(): ?string
+    public function getConfigRowId(): ?string
     {
-        return $this->data['params']['row'] ?? null;
+        return $this->data['configRowId'] ?? null;
     }
 
     public function getStatus(): string
@@ -80,14 +85,29 @@ class Job implements JsonSerializable
         return $this->data['status'];
     }
 
-    public function getTag(): ?string
+    public function getDesiredStatus(): string
     {
-        return $this->data['params']['tag'] ?? null;
+        return $this->data['desiredStatus'];
     }
 
-    public function getToken(): string
+    public function getTag(): ?string
     {
-        return $this->data['token']['token'];
+        return $this->data['tag'] ?? null;
+    }
+
+    public function getTokenString(): string
+    {
+        return $this->data['tokenString'];
+    }
+
+    public function getTokenId(): string
+    {
+        return $this->data['tokenId'];
+    }
+
+    public function getTokenDescription(): string
+    {
+        return $this->data['tokenDescription'];
     }
 
     public function getParentRunId(): string
@@ -107,6 +127,11 @@ class Job implements JsonSerializable
         return (bool) $this->data['isFinished'];
     }
 
+    public function getUsageData(): array
+    {
+        return $this->data['usageData'] ?? [];
+    }
+
     public function jsonSerialize(): array
     {
         return $this->data;
@@ -114,7 +139,7 @@ class Job implements JsonSerializable
 
     public function getTokenDecrypted(): string
     {
-        return $this->objectEncryptorFactory->getEncryptor(true)->decrypt($this->getToken());
+        return $this->objectEncryptorFactory->getEncryptor(true)->decrypt($this->getTokenString());
     }
 
     public function getConfigDataDecrypted(): array

--- a/src/JobFactory/Job.php
+++ b/src/JobFactory/Job.php
@@ -42,7 +42,7 @@ class Job implements JsonSerializable
 
     public function getComponentId(): string
     {
-        return $this->data['component'] ?? '';
+        return $this->data['componentId'] ?? '';
     }
 
     public function getConfigData(): array

--- a/src/JobFactory/NewJobDefinition.php
+++ b/src/JobFactory/NewJobDefinition.php
@@ -31,9 +31,9 @@ class NewJobDefinition implements ConfigurationInterface
         // @formatter:off
         $rootNode
             ->children()
-                ->scalarNode('token')->isRequired()->cannotBeEmpty()->end()
-                ->scalarNode('config')->end()
-                ->scalarNode('component')->isRequired()->cannotBeEmpty()->end()
+                ->scalarNode('tokenString')->isRequired()->cannotBeEmpty()->end()
+                ->scalarNode('configId')->end()
+                ->scalarNode('componentId')->isRequired()->cannotBeEmpty()->end()
                 ->arrayNode('result')->ignoreExtraKeys(false)->end()
                 ->scalarNode('mode')->defaultValue('run')
                     ->validate()
@@ -41,7 +41,7 @@ class NewJobDefinition implements ConfigurationInterface
                         ->thenInvalid('Mode must be one of "run" or "debug".')
                     ->end()
                 ->end()
-                ->scalarNode('row')->end()
+                ->scalarNode('configRowId')->end()
                 ->scalarNode('tag')->end()
                 ->scalarNode('parentRunId')->end()
                 ->arrayNode('configData')->ignoreExtraKeys(false)->end()

--- a/src/JobListOptions.php
+++ b/src/JobListOptions.php
@@ -50,8 +50,8 @@ class JobListOptions
 
     public function getQueryParameters(): array
     {
-        $arrayableProps = ['ids' => 'id', 'components' => 'component', 'configs' => 'config', 'modes' => 'mode',
-            'projects' => 'project', 'statuses' => 'status'];
+        $arrayableProps = ['ids' => 'id', 'components' => 'component', 'configs' => 'configId', 'modes' => 'mode',
+            'projects' => 'projectId', 'statuses' => 'status'];
         $scalarProps = ['startTimeFrom' => 'startTimeFrom', 'startTimeTo' => 'startTimeTo',
             'createdTimeFrom' => 'createdTimeFrom', 'createdTimeTo' => 'createdTimeTo', 'endTimeFrom' => 'endTimeFrom',
             'endTimeTo' => 'endTimeTo', 'offset' => 'offset', 'limit' => 'limit'];

--- a/src/JobListOptions.php
+++ b/src/JobListOptions.php
@@ -50,7 +50,7 @@ class JobListOptions
 
     public function getQueryParameters(): array
     {
-        $arrayableProps = ['ids' => 'id', 'components' => 'component', 'configs' => 'configId', 'modes' => 'mode',
+        $arrayableProps = ['ids' => 'id', 'components' => 'componentId', 'configs' => 'configId', 'modes' => 'mode',
             'projects' => 'projectId', 'statuses' => 'status'];
         $scalarProps = ['startTimeFrom' => 'startTimeFrom', 'startTimeTo' => 'startTimeTo',
             'createdTimeFrom' => 'createdTimeFrom', 'createdTimeTo' => 'createdTimeTo', 'endTimeFrom' => 'endTimeFrom',

--- a/tests/ClientFunctionalTest.php
+++ b/tests/ClientFunctionalTest.php
@@ -98,9 +98,6 @@ class ClientFunctionalTest extends BaseTest
             'result' => [],
             'usageData' => [],
             'isFinished' => false,
-            'startTime' => null,
-            'endTime' => null,
-            'durationSeconds' => 0,
         ];
         self::assertEquals($expected, $response);
     }
@@ -256,12 +253,13 @@ class ClientFunctionalTest extends BaseTest
             'componentId' => 'keboola.ex-db-snowflake',
             'mode' => 'run',
         ]);
+
         $client->createJob($job);
         $client = $this->getClient();
         $response = $client->listJobs(
             (new JobListOptions())
-                ->setProjects([$job->getProjectId()])
-                ->setComponents(['keboola.non-existing-component'])
+                ->setProjects(['123'])
+                ->setComponents(['keboola.non-existent'])
         );
 
         self::assertCount(0, $response);

--- a/tests/ClientFunctionalTest.php
+++ b/tests/ClientFunctionalTest.php
@@ -180,7 +180,7 @@ class ClientFunctionalTest extends BaseTest
         $response = $client->listJobs(
             (new JobListOptions())
                 ->setConfigs(['(*^&^$%£  $"£)?! \''])
-//                ->setComponents(['[]{}=žýřčšěš'])
+            //                ->setComponents(['[]{}=žýřčšěš'])
                 ->setStatuses([JobFactory::STATUS_CREATED])
         );
         self::assertCount(1, $response);

--- a/tests/ClientFunctionalTest.php
+++ b/tests/ClientFunctionalTest.php
@@ -98,6 +98,9 @@ class ClientFunctionalTest extends BaseTest
             'result' => [],
             'usageData' => [],
             'isFinished' => false,
+            'startTime' => null,
+            'endTime' => null,
+            'durationSeconds' => 0,
         ];
         self::assertEquals($expected, $response);
     }

--- a/tests/ClientFunctionalTest.php
+++ b/tests/ClientFunctionalTest.php
@@ -60,9 +60,9 @@ class ClientFunctionalTest extends BaseTest
     {
         $client = $this->getClient();
         $job = $client->getJobFactory()->createNewJob([
-            'token' => getenv('TEST_STORAGE_API_TOKEN'),
-            'config' => '454124290',
-            'component' => 'keboola.ex-db-snowflake',
+            'tokenString' => getenv('TEST_STORAGE_API_TOKEN'),
+            'configId' => '454124290',
+            'componentId' => 'keboola.ex-db-snowflake',
             'mode' => 'run',
         ]);
         $response = $client->createJob($job)->jsonSerialize();
@@ -84,7 +84,7 @@ class ClientFunctionalTest extends BaseTest
         unset($response['runId']);
         $expected = [
             'configId' => '454124290',
-            'component' => 'keboola.ex-db-snowflake',
+            'componentId' => 'keboola.ex-db-snowflake',
             'mode' => 'run',
             'configRowId' => null,
             'tag' => null,
@@ -98,6 +98,9 @@ class ClientFunctionalTest extends BaseTest
             'result' => [],
             'usageData' => [],
             'isFinished' => false,
+            'startTime' => null,
+            'endTime' => null,
+            'durationSeconds' => 0,
         ];
         self::assertEquals($expected, $response);
     }
@@ -106,9 +109,9 @@ class ClientFunctionalTest extends BaseTest
     {
         $client = $this->getClient();
         $job = $client->getJobFactory()->createNewJob([
-            'token' => getenv('TEST_STORAGE_API_TOKEN'),
-            'config' => '454124290',
-            'component' => 'keboola.ex-db-snowflake',
+            'tokenString' => getenv('TEST_STORAGE_API_TOKEN'),
+            'configId' => '454124290',
+            'componentId' => 'keboola.ex-db-snowflake',
             'mode' => 'run',
         ]);
         $createdJob = $client->createJob($job);
@@ -134,9 +137,9 @@ class ClientFunctionalTest extends BaseTest
     {
         $client = $this->getClient();
         $job = $client->getJobFactory()->createNewJob([
-            'token' => getenv('TEST_STORAGE_API_TOKEN'),
-            'config' => '454124290',
-            'component' => 'keboola.ex-db-snowflake',
+            'tokenString' => getenv('TEST_STORAGE_API_TOKEN'),
+            'configId' => '454124290',
+            'componentId' => 'keboola.ex-db-snowflake',
             'mode' => 'run',
         ]);
         $createdJob = $client->createJob($job);
@@ -152,9 +155,9 @@ class ClientFunctionalTest extends BaseTest
     {
         $client = $this->getClient();
         $job = $client->getJobFactory()->createNewJob([
-            'token' => getenv('TEST_STORAGE_API_TOKEN'),
-            'config' => '454124290',
-            'component' => 'keboola.ex-db-snowflake',
+            'tokenString' => getenv('TEST_STORAGE_API_TOKEN'),
+            'configId' => '454124290',
+            'componentId' => 'keboola.ex-db-snowflake',
             'mode' => 'run',
         ]);
         $createdJob = $client->createJob($job);
@@ -169,9 +172,9 @@ class ClientFunctionalTest extends BaseTest
     {
         $client = $this->getClient();
         $job = $client->getJobFactory()->createNewJob([
-            'token' => getenv('TEST_STORAGE_API_TOKEN'),
-            'config' => '(*^&^$%£  $"£)?! \'',
-            'component' => '[]{}=žýřčšěš',
+            'tokenString' => getenv('TEST_STORAGE_API_TOKEN'),
+            'configId' => '(*^&^$%£  $"£)?! \'',
+            'componentId' => '[]{}=žýřčšěš',
             'mode' => 'run',
         ]);
         $createdJob = $client->createJob($job);
@@ -207,9 +210,9 @@ class ClientFunctionalTest extends BaseTest
     {
         $client = $this->getClient();
         $job = $client->getJobFactory()->createNewJob([
-            'token' => getenv('TEST_STORAGE_API_TOKEN'),
-            'config' => '454124290',
-            'component' => 'keboola.ex-db-snowflake',
+            'tokenString' => getenv('TEST_STORAGE_API_TOKEN'),
+            'configId' => '454124290',
+            'componentId' => 'keboola.ex-db-snowflake',
             'mode' => 'run',
         ]);
         $createdJob = $client->createJob($job);
@@ -227,9 +230,9 @@ class ClientFunctionalTest extends BaseTest
     {
         $client = $this->getClient();
         $job = $client->getJobFactory()->createNewJob([
-            'token' => getenv('TEST_STORAGE_API_TOKEN'),
-            'config' => '454124290',
-            'component' => 'keboola.ex-db-snowflake',
+            'tokenString' => getenv('TEST_STORAGE_API_TOKEN'),
+            'configId' => '454124290',
+            'componentId' => 'keboola.ex-db-snowflake',
             'mode' => 'run',
         ]);
         $createdJob = $client->createJob($job);
@@ -248,9 +251,9 @@ class ClientFunctionalTest extends BaseTest
         $client = $this->getClient();
 
         $job = $client->getJobFactory()->createNewJob([
-            'token' => getenv('TEST_STORAGE_API_TOKEN'),
-            'config' => '454124290',
-            'component' => 'keboola.ex-db-snowflake',
+            'tokenString' => getenv('TEST_STORAGE_API_TOKEN'),
+            'configId' => '454124290',
+            'componentId' => 'keboola.ex-db-snowflake',
             'mode' => 'run',
         ]);
         $client->createJob($job);

--- a/tests/ClientFunctionalTest.php
+++ b/tests/ClientFunctionalTest.php
@@ -261,7 +261,7 @@ class ClientFunctionalTest extends BaseTest
         $client = $this->getClient();
         $response = $client->listJobs(
             (new JobListOptions())
-                ->setProjects(['123'])
+                ->setProjects([$job->getProjectId()])
                 ->setComponents(['keboola.non-existent'])
         );
 

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -128,7 +128,7 @@ class ClientTest extends BaseTest
                     "status": "created",
                     "desiredStatus": "processing",
                     "mode": "run",
-                    "component": "keboola.test",
+                    "componentId": "keboola.test",
                     "configId": "123456",
                     "configData": {
                         "parameters": {
@@ -208,7 +208,7 @@ class ClientTest extends BaseTest
                     "status": "created",
                     "desiredStatus": "processing",
                     "mode": "run",
-                    "component": "keboola.test",
+                    "componentId": "keboola.test",
                     "configId": "123456",
                     "configData": {
                         "parameters": {
@@ -262,7 +262,7 @@ class ClientTest extends BaseTest
                     "status": "created",
                     "desiredStatus": "processing",
                     "mode": "run",
-                    "component": "keboola.test",
+                    "componentId": "keboola.test",
                     "configId": "123456",
                     "configData": {
                         "parameters": {
@@ -451,7 +451,7 @@ class ClientTest extends BaseTest
                     "status": "created",
                     "desiredStatus": "processing",
                     "mode": "run",
-                    "component": "keboola.test",
+                    "componentId": "keboola.test",
                     "configId": "123456",
                     "configData": {
                         "parameters": {
@@ -499,7 +499,7 @@ class ClientTest extends BaseTest
                     "status": "created",
                     "desiredStatus": "processing",
                     "mode": "run",
-                    "component": "th!$ |& n°t valid",
+                    "componentId": "th!$ |& n°t valid",
                     "configId": "123456",
                     "configData": {
                         "parameters": {
@@ -531,7 +531,7 @@ class ClientTest extends BaseTest
 
         $request = $mock->getLastRequest();
         self::assertEquals(
-            'component%5B%5D=th%21%24+%7C%26+n%C2%B0t+valid&' .
+            'componentId%5B%5D=th%21%24+%7C%26+n%C2%B0t+valid&' .
                 'projectId%5B%5D=%C5%A1%C4%9B%C5%99%C4%8D%21%40%23%25%5E%24%26&limit=100',
             $request->getUri()->getQuery()
         );

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -120,25 +120,24 @@ class ClientTest extends BaseTest
                 ['Content-Type' => 'application/json'],
                 '{
                     "id": "123",
-                    "project": {
-                        "id": "456"
-                    },
-                    "token": {
-                        "id": "789",
-                        "token": "KBC::ProjectSecure::aSdF"
-                    },
+                    "projectId": "456",
+                    "projectName": "Test project",
+                    "tokenId": "789",
+                    "tokenString": "KBC::ProjectSecure::aSdF",
+                    "tokenDescription": "my token",
                     "status": "created",
-                    "params": {
-                        "mode": "run",
-                        "component": "keboola.test",
-                        "config": "123456",
-                        "configData": {
-                            "parameters": {
-                                "foo": "bar"
-                            }
+                    "desiredStatus": "processing",
+                    "mode": "run",
+                    "component": "keboola.test",
+                    "configId": "123456",
+                    "configData": {
+                        "parameters": {
+                            "foo": "bar"
                         }
                     },
-                    "result": {}
+                    "result": {},
+                    "usageData": {},
+                    "isFinished": false
                 }'
             ),
         ]);
@@ -153,13 +152,15 @@ class ClientTest extends BaseTest
         self::assertEquals('123456', $job->getConfigId());
         self::assertEquals('keboola.test', $job->getComponentId());
         self::assertEquals('456', $job->getProjectId());
+        self::assertEquals('Test project', $job->getProjectName());
         self::assertEquals('run', $job->getMode());
         self::assertEquals('created', $job->getStatus());
         self::assertEquals([], $job->getResult());
+        self::assertEquals([], $job->getUsageData());
         self::assertNull($job->getTag());
-        self::assertNull($job->getRowId());
+        self::assertNull($job->getConfigRowId());
         self::assertFalse($job->isFinished());
-        self::assertStringStartsWith('KBC::ProjectSecure::', $job->getToken());
+        self::assertStringStartsWith('KBC::ProjectSecure::', $job->getTokenString());
         self::assertEquals(['parameters' => ['foo' => 'bar']], $job->getConfigData());
         self::assertCount(1, $requestHistory);
         /** @var Request $request */
@@ -199,19 +200,24 @@ class ClientTest extends BaseTest
                 ['Content-Type' => 'application/json'],
                 '{
                     "id": "123",
-                    "project": {
-                        "id": "456"
-                    },
-                    "token": {
-                        "id": "789",
-                        "token": "KBC::ProjectSecure::eJwBYAGf"
-                    },
+                    "projectId": "456",
+                    "projectName": "Test project",
+                    "tokenId": "789",
+                    "tokenString": "KBC::ProjectSecure::aSdF",
+                    "tokenDescription": "my token",
                     "status": "created",
-                    "params": {
-                        "mode": "run",
-                        "component": "keboola.test",
-                        "config": "123456"
-                    }
+                    "desiredStatus": "processing",
+                    "mode": "run",
+                    "component": "keboola.test",
+                    "configId": "123456",
+                    "configData": {
+                        "parameters": {
+                            "foo": "bar"
+                        }
+                    },
+                    "result": {},
+                    "usageData": {},
+                    "isFinished": false
                 }'
             ),
         ]);
@@ -248,19 +254,24 @@ class ClientTest extends BaseTest
                 ['Content-Type' => 'application/json'],
                 '{
                     "id": "123",
-                    "project": {
-                        "id": "456"
-                    },
-                    "token": {
-                        "id": "789",
-                        "token": "KBC::ProjectSecure::aSdF"
-                    },
+                    "projectId": "456",
+                    "projectName": "Test project",
+                    "tokenId": "789",
+                    "tokenString": "KBC::ProjectSecure::aSdF",
+                    "tokenDescription": "my token",
                     "status": "created",
-                    "params": {
-                        "mode": "run",
-                        "component": "keboola.test",
-                        "config": "123456"
-                    }
+                    "desiredStatus": "processing",
+                    "mode": "run",
+                    "component": "keboola.test",
+                    "configId": "123456",
+                    "configData": {
+                        "parameters": {
+                            "foo": "bar"
+                        }
+                    },
+                    "result": {},
+                    "usageData": {},
+                    "isFinished": false
                 }'
             ),
         ]);
@@ -385,7 +396,7 @@ class ClientTest extends BaseTest
         $client = $this->getClient(['handler' => $stack]);
         $job = self::getMockBuilder(Job::class)
             ->disableOriginalConstructor()
-            ->setMethods(['jsonSerialize'])
+            ->onlyMethods(['jsonSerialize'])
             ->getMock();
         $job->method('jsonSerialize')->willReturn(['foo' => fopen('php://memory', 'rw')]);
         /** @var Job $job */
@@ -400,16 +411,13 @@ class ClientTest extends BaseTest
             new Response(
                 200,
                 ['Content-Type' => 'application/json'],
-                '[{
-                    "id": "123",
-                    "project": {
-                        "id": "456"
-                    },
-                    "token": {
-                        "id": "789",
-                        "token": "KBC::ProjectSecure::aSdF"
-                    },
-                    "status": "created"
+                '[{                    
+                    "projectId": "456",
+                    "projectName": "Test project",
+                    "tokenId": "789",
+                    "tokenString": "KBC::ProjectSecure::aSdF",
+                    "tokenDescription": "my token",
+                    "status": "created"                    
                 }]'
             ),
         ]);
@@ -423,7 +431,7 @@ class ClientTest extends BaseTest
         $jobs = $client->getJobsWithIds(['123']);
         self::assertCount(0, $jobs);
         self::assertTrue($logger->hasErrorThatContains(
-            'Failed to parse Job data: The child node "params" at path "job" must be configured.'
+            'Failed to parse Job data: The child node "id" at path "job" must be configured.'
         ));
     }
 
@@ -435,19 +443,24 @@ class ClientTest extends BaseTest
                 ['Content-Type' => 'application/json'],
                 '[{
                     "id": "123",
-                    "project": {
-                        "id": "456"
-                    },
-                    "token": {
-                        "id": "789",
-                        "token": "KBC::ProjectSecure::aSdF"
-                    },
+                    "projectId": "456",
+                    "projectName": "Test project",
+                    "tokenId": "789",
+                    "tokenString": "KBC::ProjectSecure::aSdF",
+                    "tokenDescription": "my token",
                     "status": "created",
-                    "params": {
-                        "mode": "run",
-                        "component": "keboola.test",
-                        "config": "123456"
-                    }
+                    "desiredStatus": "processing",
+                    "mode": "run",
+                    "component": "keboola.test",
+                    "configId": "123456",
+                    "configData": {
+                        "parameters": {
+                            "foo": "bar"
+                        }
+                    },
+                    "result": {},
+                    "usageData": {},
+                    "isFinished": false
                 }]'
             ),
         ]);
@@ -467,7 +480,7 @@ class ClientTest extends BaseTest
         self::assertEquals('456', $job->getProjectId());
 
         $request = $mock->getLastRequest();
-        self::assertEquals('project%5B%5D=456&limit=100', $request->getUri()->getQuery());
+        self::assertEquals('projectId%5B%5D=456&limit=100', $request->getUri()->getQuery());
     }
 
     public function testClientGetJobsEscaping(): void
@@ -478,19 +491,24 @@ class ClientTest extends BaseTest
                 ['Content-Type' => 'application/json'],
                 '[{
                     "id": "123",
-                    "project": {
-                        "id": "šěřč!@#%^$&"
-                    },
-                    "token": {
-                        "id": "789",
-                        "token": "KBC::ProjectSecure::aSdF"
-                    },
+                    "projectId": "šěřč!@#%^$&",
+                    "projectName": "Test project",
+                    "tokenId": "789",
+                    "tokenString": "KBC::ProjectSecure::aSdF",
+                    "tokenDescription": "my token",
                     "status": "created",
-                    "params": {
-                        "mode": "run",
-                        "component": "th!$ |& n°t valid",
-                        "config": "123456"
-                    }
+                    "desiredStatus": "processing",
+                    "mode": "run",
+                    "component": "th!$ |& n°t valid",
+                    "configId": "123456",
+                    "configData": {
+                        "parameters": {
+                            "foo": "bar"
+                        }
+                    },
+                    "result": {},
+                    "usageData": {},
+                    "isFinished": false
                 }]'
             ),
         ]);
@@ -514,7 +532,7 @@ class ClientTest extends BaseTest
         $request = $mock->getLastRequest();
         self::assertEquals(
             'component%5B%5D=th%21%24+%7C%26+n%C2%B0t+valid&' .
-                'project%5B%5D=%C5%A1%C4%9B%C5%99%C4%8D%21%40%23%25%5E%24%26&limit=100',
+                'projectId%5B%5D=%C5%A1%C4%9B%C5%99%C4%8D%21%40%23%25%5E%24%26&limit=100',
             $request->getUri()->getQuery()
         );
     }

--- a/tests/JobFactory/FullJobDefinitionTest.php
+++ b/tests/JobFactory/FullJobDefinitionTest.php
@@ -61,7 +61,7 @@ class FullJobDefinitionTest extends BaseTest
         ];
         $definition = new FullJobDefinition();
         self::assertEquals(array_merge($data, [
-            'isFinished' => false
+            'isFinished' => false,
         ]), $definition->processData($data));
     }
 

--- a/tests/JobFactory/FullJobDefinitionTest.php
+++ b/tests/JobFactory/FullJobDefinitionTest.php
@@ -22,7 +22,7 @@ class FullJobDefinitionTest extends BaseTest
             'configData' => [
                 'foo' => 'bar',
             ],
-            'component' => 'keboola.test',
+            'componentId' => 'keboola.test',
             'mode' => 'run',
             'id' => '1234',
             'result' => [
@@ -46,7 +46,7 @@ class FullJobDefinitionTest extends BaseTest
             'tokenId' => '12345',
             'projectId' => '123',
             'configId' => '123',
-            'component' => 'keboola.test',
+            'componentId' => 'keboola.test',
             'mode' => 'run',
             'configRowId' => '234',
             'configData' => [
@@ -77,7 +77,7 @@ class FullJobDefinitionTest extends BaseTest
                 'id' => 123456,
                 'name' => 'Test orchestration',
             ],
-            'component' => 'orchestrator',
+            'componentId' => 'orchestrator',
             'initializedBy' => 'trigger',
             'initiator' => [
                 'id' => 199182,
@@ -91,7 +91,7 @@ class FullJobDefinitionTest extends BaseTest
                     'actionParameters' => [
                         'config' => '554424643',
                     ],
-                    'component' => 'keboola.ex-db-snowflake',
+                    'componentId' => 'keboola.ex-db-snowflake',
                     'action' => 'run',
                     'active' => true,
                     'continueOnFailure' => false,
@@ -122,13 +122,13 @@ class FullJobDefinitionTest extends BaseTest
                     'projectId' => '123',
                     'status' => 'created',
                     'configId' => '123',
-                    'component' => 'keboola.test',
+                    'componentId' => 'keboola.test',
                     'mode' => 'run',
                 ],
                 'The child node "tokenString" at path "job" must be configured.',
             ],
             /*
-            'Missing component' => [
+            'Missing componentId' => [
                 [
                     'token' => [
                         'token' => getenv('TEST_STORAGE_API_TOKEN'),
@@ -144,7 +144,7 @@ class FullJobDefinitionTest extends BaseTest
                         'mode' => 'run',
                     ],
                 ],
-                'The child node "component" at path "job.params" must be configured.',
+                'The child node "componentId" at path "job.params" must be configured.',
             ],
             'Missing mode' => [
                 [
@@ -159,7 +159,7 @@ class FullJobDefinitionTest extends BaseTest
                     'status' => 'created',
                     'params' => [
                         'configId' => '123',
-                        'component' => 'keboola.test',
+                        'componentId' => 'keboola.test',
                     ],
                 ],
                 'The child node "mode" at path "job.params" must be configured.',
@@ -173,7 +173,7 @@ class FullJobDefinitionTest extends BaseTest
                     'id' => '12345',
                     'status' => 'created',
                     'configId' => '123',
-                    'component' => 'keboola.test',
+                    'componentId' => 'keboola.test',
                     'mode' => 'invalid',
                 ],
                 'Invalid configuration for path "job.mode": Mode must be one of "run" ' .
@@ -188,7 +188,7 @@ class FullJobDefinitionTest extends BaseTest
                     'status' => 'created',
                     'configId' => '123',
                     'configData' => '345',
-                    'component' => 'keboola.test',
+                    'componentId' => 'keboola.test',
                     'mode' => 'run',
                 ],
                 'Invalid type for path "job.configData". Expected array, but got string',
@@ -201,7 +201,7 @@ class FullJobDefinitionTest extends BaseTest
                     'id' => '12345',
                     'status' => 'created',
                     'configId' => '123',
-                    'component' => 'keboola.test',
+                    'componentId' => 'keboola.test',
                     'mode' => 'run',
                     'configRowId' => ['123'],
                 ],
@@ -215,7 +215,7 @@ class FullJobDefinitionTest extends BaseTest
                     'id' => '12345',
                     'status' => 'created',
                     'configId' => '123',
-                    'component' => 'keboola.test',
+                    'componentId' => 'keboola.test',
                     'mode' => 'run',
                     'tag' => ['234'],
                 ],
@@ -228,7 +228,7 @@ class FullJobDefinitionTest extends BaseTest
                     'projectId' => '123',
                     'status' => 'created',
                     'configId' => '123',
-                    'component' => 'keboola.test',
+                    'componentId' => 'keboola.test',
                     'mode' => 'run',
                 ],
                 'The child node "id" at path "job" must be configured.',
@@ -240,7 +240,7 @@ class FullJobDefinitionTest extends BaseTest
                     'projectId' => '123',
                     'id' => '12345',
                     'configId' => '123',
-                    'component' => 'keboola.test',
+                    'componentId' => 'keboola.test',
                     'mode' => 'run',
                 ],
                 'The child node "status" at path "job" must be configured.',
@@ -253,7 +253,7 @@ class FullJobDefinitionTest extends BaseTest
                     'id' => '12345',
                     'status' => 'invalid',
                     'configId' => '123',
-                    'component' => 'keboola.test',
+                    'componentId' => 'keboola.test',
                     'mode' => 'run',
                 ],
                 'Invalid configuration for path "job.status": Status must be one of cancelled, created, error, ' .
@@ -266,7 +266,7 @@ class FullJobDefinitionTest extends BaseTest
                     'id' => '12345',
                     'status' => 'created',
                     'configId' => '123',
-                    'component' => 'keboola.test',
+                    'componentId' => 'keboola.test',
                     'mode' => 'run',
                 ],
                 'The child node "projectId" at path "job" must be configured.',
@@ -278,7 +278,7 @@ class FullJobDefinitionTest extends BaseTest
                     'id' => '12345',
                     'status' => 'created',
                     'configId' => '123',
-                    'component' => 'keboola.test',
+                    'componentId' => 'keboola.test',
                     'mode' => 'run',
                 ],
                 'The child node "tokenId" at path "job" must be configured.',

--- a/tests/JobFactory/JobTest.php
+++ b/tests/JobFactory/JobTest.php
@@ -13,22 +13,17 @@ class JobTest extends BaseTest
     /** @var array */
     private $jobData = [
         'id' => '123456456',
-        'params' => [
-            'config' => '454124290',
-            'component' => 'keboola.ex-db-snowflake',
-            'mode' => 'run',
-            'configData' => [
-                'parameters' => ['foo' => 'bar'],
-            ],
+        'configId' => '454124290',
+        'component' => 'keboola.ex-db-snowflake',
+        'mode' => 'run',
+        'configData' => [
+            'parameters' => ['foo' => 'bar'],
         ],
         'status' => 'created',
-        'project' => [
-            'id' => '123',
-        ],
-        'token' => [
-            'id' => '456',
-            'token' => 'KBC::ProjectSecure::token',
-        ],
+        'desiredStatus' => 'processing',
+        'projectId' => '123',
+        'tokenId' => '456',
+        'tokenString' => 'KBC::ProjectSecure::token',
     ];
 
     public function setUp(): void
@@ -51,7 +46,7 @@ class JobTest extends BaseTest
         self::assertEquals('454124290', $this->getJob()->getConfigId());
 
         $jobDataWithoutConfigId = $this->jobData;
-        unset($jobDataWithoutConfigId['params']['config']);
+        unset($jobDataWithoutConfigId['configId']);
         self::assertNull($this->getJob($jobDataWithoutConfigId)->getConfigId());
     }
 
@@ -95,11 +90,11 @@ class JobTest extends BaseTest
 
     public function testGetRowId(): void
     {
-        self::assertNull($this->getJob()->getRowId());
+        self::assertNull($this->getJob()->getConfigRowId());
 
         $jobDataWithRowId = $this->jobData;
-        $jobDataWithRowId['params']['row'] = '123456789';
-        self::assertSame('123456789', $this->getJob($jobDataWithRowId)->getRowId());
+        $jobDataWithRowId['configRowId'] = '123456789';
+        self::assertSame('123456789', $this->getJob($jobDataWithRowId)->getConfigRowId());
     }
 
     public function testGetStatus(): void
@@ -112,13 +107,13 @@ class JobTest extends BaseTest
         self::assertNull($this->getJob()->getTag());
 
         $jobDataWithTag = $this->jobData;
-        $jobDataWithTag['params']['tag'] = '1.1';
+        $jobDataWithTag['tag'] = '1.1';
         self::assertSame('1.1', $this->getJob($jobDataWithTag)->getTag());
     }
 
     public function testGetToken(): void
     {
-        self::assertStringStartsWith('KBC::ProjectSecure::', $this->getJob()->getToken());
+        self::assertStringStartsWith('KBC::ProjectSecure::', $this->getJob()->getTokenString());
     }
 
     public function testIsFinished(): void
@@ -134,14 +129,14 @@ class JobTest extends BaseTest
     public function testIsLegacyOrchestrator(): void
     {
         $jobData = $this->jobData;
-        $jobData['params']['component'] = 'orchestrator';
+        $jobData['component'] = 'orchestrator';
         self::assertTrue($this->getJob($jobData)->isLegacyComponent());
     }
 
     public function testLegacyOrchestratorJob(): void
     {
         $jobData = $this->jobData;
-        unset($jobData['params']['component']);
+        unset($jobData['component']);
         $job = $this->getJob($jobData);
         self::assertEquals('', $job->getComponentId());
         self::assertTrue($job->isLegacyComponent());

--- a/tests/JobFactory/JobTest.php
+++ b/tests/JobFactory/JobTest.php
@@ -14,7 +14,7 @@ class JobTest extends BaseTest
     private $jobData = [
         'id' => '123456456',
         'configId' => '454124290',
-        'component' => 'keboola.ex-db-snowflake',
+        'componentId' => 'keboola.ex-db-snowflake',
         'mode' => 'run',
         'configData' => [
             'parameters' => ['foo' => 'bar'],
@@ -129,14 +129,14 @@ class JobTest extends BaseTest
     public function testIsLegacyOrchestrator(): void
     {
         $jobData = $this->jobData;
-        $jobData['component'] = 'orchestrator';
+        $jobData['componentId'] = 'orchestrator';
         self::assertTrue($this->getJob($jobData)->isLegacyComponent());
     }
 
     public function testLegacyOrchestratorJob(): void
     {
         $jobData = $this->jobData;
-        unset($jobData['component']);
+        unset($jobData['componentId']);
         $job = $this->getJob($jobData);
         self::assertEquals('', $job->getComponentId());
         self::assertTrue($job->isLegacyComponent());

--- a/tests/JobFactory/NewJobDefinitionTest.php
+++ b/tests/JobFactory/NewJobDefinitionTest.php
@@ -20,9 +20,13 @@ class NewJobDefinitionTest extends BaseTest
         ];
         $definition = new NewJobDefinition();
         $processed = $definition->processData($data);
-        $data['mode'] = 'run';
-        $data['result'] = [];
-        self::assertEquals($data, $processed);
+        self::assertEquals(
+            array_merge($data, [
+                'mode' => 'run',
+                'result' => [],
+            ]),
+            $processed
+        );
     }
 
     public function testValidJobFull(): void

--- a/tests/JobFactory/NewJobDefinitionTest.php
+++ b/tests/JobFactory/NewJobDefinitionTest.php
@@ -13,9 +13,9 @@ class NewJobDefinitionTest extends BaseTest
     public function testValidJobMinimal(): void
     {
         $data = [
-            'token' => getenv('TEST_STORAGE_API_TOKEN'),
-            'config' => '123',
-            'component' => 'keboola.test',
+            'tokenString' => getenv('TEST_STORAGE_API_TOKEN'),
+            'configId' => '123',
+            'componentId' => 'keboola.test',
             'result' => [],
         ];
         $definition = new NewJobDefinition();
@@ -32,12 +32,12 @@ class NewJobDefinitionTest extends BaseTest
     public function testValidJobFull(): void
     {
         $data = [
-            'token' => getenv('TEST_STORAGE_API_TOKEN'),
+            'tokenString' => getenv('TEST_STORAGE_API_TOKEN'),
             'parentRunId' => '12345',
-            'config' => '123',
-            'component' => 'keboola.test',
+            'configId' => '123',
+            'componentId' => 'keboola.test',
             'mode' => 'run',
-            'row' => '234',
+            'configRowId' => '234',
             'configData' => [
                 'parameters' => [
                     'foo' => 'bar',
@@ -55,54 +55,54 @@ class NewJobDefinitionTest extends BaseTest
         return [
             'Missing token' => [
                 [
-                    'config' => '123',
-                    'component' => 'keboola.test',
+                    'configId' => '123',
+                    'componentId' => 'keboola.test',
                     'mode' => 'run',
                 ],
-                'The child node "token" at path "job" must be configured.',
+                'The child node "tokenString" at path "job" must be configured.',
             ],
-            'Missing component' => [
+            'Missing componentId' => [
                 [
-                    'token' => getenv('TEST_STORAGE_API_TOKEN'),
-                    'config' => '123',
+                    'tokenString' => getenv('TEST_STORAGE_API_TOKEN'),
+                    'configId' => '123',
                     'mode' => 'run',
                 ],
-                'The child node "component" at path "job" must be configured.',
+                'The child node "componentId" at path "job" must be configured.',
             ],
             'Invalid mode' => [
                 [
-                    'token' => getenv('TEST_STORAGE_API_TOKEN'),
-                    'config' => '123',
-                    'component' => 'keboola.test',
+                    'tokenString' => getenv('TEST_STORAGE_API_TOKEN'),
+                    'configId' => '123',
+                    'componentId' => 'keboola.test',
                     'mode' => 'invalid',
                 ],
                 'Invalid configuration for path "job.mode": Mode must be one of "run" or "debug".',
             ],
             'Invalid configData' => [
                 [
-                    'token' => getenv('TEST_STORAGE_API_TOKEN'),
-                    'config' => '123',
+                    'tokenString' => getenv('TEST_STORAGE_API_TOKEN'),
+                    'configId' => '123',
                     'configData' => '345',
-                    'component' => 'keboola.test',
+                    'componentId' => 'keboola.test',
                     'mode' => 'run',
                 ],
                 'Invalid type for path "job.configData". Expected array, but got string',
             ],
             'Invalid row' => [
                 [
-                    'token' => getenv('TEST_STORAGE_API_TOKEN'),
-                    'config' => '123',
-                    'component' => 'keboola.test',
+                    'tokenString' => getenv('TEST_STORAGE_API_TOKEN'),
+                    'configId' => '123',
+                    'componentId' => 'keboola.test',
                     'mode' => 'run',
-                    'row' => ['123'],
+                    'configRowId' => ['123'],
                 ],
-                'Invalid type for path "job.row". Expected scalar, but got array.',
+                'Invalid type for path "job.configRowId". Expected scalar, but got array.',
             ],
             'Invalid tag' => [
                 [
-                    'token' => getenv('TEST_STORAGE_API_TOKEN'),
-                    'config' => '123',
-                    'component' => 'keboola.test',
+                    'tokenString' => getenv('TEST_STORAGE_API_TOKEN'),
+                    'configId' => '123',
+                    'componentId' => 'keboola.test',
                     'mode' => 'run',
                     'tag' => ['234'],
                 ],
@@ -110,9 +110,9 @@ class NewJobDefinitionTest extends BaseTest
             ],
             'Invalid result' => [
                 [
-                    'token' => getenv('TEST_STORAGE_API_TOKEN'),
-                    'config' => '123',
-                    'component' => 'keboola.test',
+                    'tokenString' => getenv('TEST_STORAGE_API_TOKEN'),
+                    'configId' => '123',
+                    'componentId' => 'keboola.test',
                     'mode' => 'run',
                     'tag' => '234',
                     'result' => 'invalid',
@@ -121,10 +121,10 @@ class NewJobDefinitionTest extends BaseTest
             ],
             'Invalid run id' => [
                 [
-                    'token' => getenv('TEST_STORAGE_API_TOKEN'),
+                    'tokenString' => getenv('TEST_STORAGE_API_TOKEN'),
                     'parentRunId' => ['123', '345'],
-                    'config' => '123',
-                    'component' => 'keboola.test',
+                    'configId' => '123',
+                    'componentId' => 'keboola.test',
                     'mode' => 'run',
                     'tag' => ['234'],
                 ],

--- a/tests/JobFactoryTest.php
+++ b/tests/JobFactoryTest.php
@@ -44,9 +44,9 @@ class JobFactoryTest extends BaseTest
     {
         $factory = $this->getJobFactory();
         $data = [
-            'token' => getenv('TEST_STORAGE_API_TOKEN'),
-            'config' => '123',
-            'component' => 'keboola.test',
+            'tokenString' => getenv('TEST_STORAGE_API_TOKEN'),
+            'configId' => '123',
+            'componentId' => 'keboola.test',
             'mode' => 'run',
         ];
         $job = $factory->createNewJob($data);
@@ -65,12 +65,12 @@ class JobFactoryTest extends BaseTest
     {
         $factory = $this->getJobFactory();
         $data = [
-            'token' => getenv('TEST_STORAGE_API_TOKEN'),
-            'config' => 123,
-            'component' => 123,
+            'tokenString' => getenv('TEST_STORAGE_API_TOKEN'),
+            'configId' => 123,
+            'componentId' => 123,
             'mode' => 'run',
             'tag' => 123,
-            'row' => 123,
+            'configRowId' => 123,
             'parentRunId' => 1234.567,
         ];
         $job = $factory->createNewJob($data);
@@ -84,7 +84,7 @@ class JobFactoryTest extends BaseTest
         self::assertSame('123', $job->getTag());
         self::assertSame('1234.567.' . $job->getId(), $job->getRunId());
         self::assertSame('1234.567', $job->getParentRunId());
-        self::assertSame('123', $job->jsonSerialize()['configId']);
+        self::assertSame('123', $job->jsonSerialize()['componentId']);
         self::assertSame('123', $job->jsonSerialize()['configRowId']);
         self::assertSame('123', $job->jsonSerialize()['tag']);
         self::assertSame('1234.567.' . $job->getId(), $job->jsonSerialize()['runId']);
@@ -94,9 +94,9 @@ class JobFactoryTest extends BaseTest
     {
         $factory = $this->getJobFactory();
         $data = [
-            'token' => getenv('TEST_STORAGE_API_TOKEN'),
-            'config' => '123',
-            'component' => 'keboola.test',
+            'tokenString' => getenv('TEST_STORAGE_API_TOKEN'),
+            'configId' => '123',
+            'componentId' => 'keboola.test',
             'mode' => 'run',
         ];
         $job = $factory->createNewJob($data);
@@ -114,12 +114,12 @@ class JobFactoryTest extends BaseTest
     {
         $factory = $this->getJobFactory();
         $data = [
-            'token' => getenv('TEST_STORAGE_API_TOKEN'),
+            'tokenString' => getenv('TEST_STORAGE_API_TOKEN'),
             'parentRunId' => '2345',
-            'config' => '123',
-            'component' => 'keboola.test',
+            'configId' => '123',
+            'componentId' => 'keboola.test',
             'mode' => 'run',
-            'row' => '234',
+            'configRowId' => '234',
             'configData' => [
                 'parameters' => [
                     'foo' => 'bar',
@@ -154,10 +154,10 @@ class JobFactoryTest extends BaseTest
                 'id' => '12345',
                 'token' => getenv('TEST_STORAGE_API_TOKEN'),
             ],
-            'component' => 'orchestrator',
+            'componentId' => 'orchestrator',
             'command' => 'run',
             'params' => [
-                'config' => 456789,
+                'configId' => 456789,
                 'mode' => 'run',
                 'row' => null,
                 'tag' => null,
@@ -179,7 +179,7 @@ class JobFactoryTest extends BaseTest
         $jobData = [
             'id' => '664651692',
             'status' => 'waiting',
-            'configId' => '123',
+            'desiredStatus' => 'processing',
             'mode' => 'run',
             'projectId' => '219',
             'tokenId' => '12345',
@@ -187,7 +187,7 @@ class JobFactoryTest extends BaseTest
         ];
 
         self::expectException(ClientException::class);
-        self::expectExceptionMessage('The child node "component" at path "job" must be configured.');
+        self::expectExceptionMessage('The child node "componentId" at path "job" must be configured.');
         $this->getJobFactory()->loadFromExistingJobData($jobData);
     }
 
@@ -209,14 +209,14 @@ class JobFactoryTest extends BaseTest
                 'description' => 'john.doe@keboola.com',
                 'token' => getenv('TEST_STORAGE_API_TOKEN'),
             ],
-            'component' => 'transformation',
+            'componentId' => 'transformation',
             'command' => 'run',
             'params' => [
                 'call' => 'run',
                 'mode' => 'full',
                 'phases' => [],
                 'transformations' => [],
-                'config' => '137869',
+                'configId' => '137869',
                 'configBucketId' => '137869',
             ],
             'result' => [],
@@ -237,7 +237,7 @@ class JobFactoryTest extends BaseTest
             'url' => 'https://queue.east-us-2.azure.keboola.com/jobs/138361',
         ];
         $job = $this->getJobFactory()->loadFromExistingJobData($jobData);
-        $jobData['params']['component'] = 'transformation';
+        $jobData['params']['componentId'] = 'transformation';
         $jobData['params']['row'] = null;
         $jobData['params']['tag'] = null;
         self::assertEquals($jobData, $job->jsonSerialize());
@@ -255,9 +255,9 @@ class JobFactoryTest extends BaseTest
     {
         $factory = $this->getJobFactory();
         $data = [
-            'token' => getenv('TEST_STORAGE_API_TOKEN'),
-            'config' => '123',
-            'component' => 'keboola.test',
+            'tokenString' => getenv('TEST_STORAGE_API_TOKEN'),
+            'configId' => '123',
+            'componentId' => 'keboola.test',
             'mode' => 'run',
             'tag' => 'latest',
             'configData' => [
@@ -282,21 +282,21 @@ class JobFactoryTest extends BaseTest
     public function testCreateInvalidJob(): void
     {
         $jobData = [
-            'config' => '123',
-            'component' => 'keboola.test',
+            'configId' => '123',
+            'componentId' => 'keboola.test',
             'mode' => 'run',
         ];
         self::expectException(ClientException::class);
-        self::expectExceptionMessage('The child node "token" at path "job" must be configured.');
+        self::expectExceptionMessage('The child node "tokenString" at path "job" must be configured.');
         $this->getJobFactory()->createNewJob($jobData);
     }
 
     public function testCreateInvalidToken(): void
     {
         $data = [
-            'token' => 'invalid',
-            'config' => '123',
-            'component' => 'keboola.test',
+            'tokenString' => 'invalid',
+            'configId' => '123',
+            'componentId' => 'keboola.test',
             'mode' => 'run',
         ];
         self::expectException(ClientException::class);
@@ -326,14 +326,14 @@ class JobFactoryTest extends BaseTest
 
         $factory = $this->getJobFactory();
         $data = [
-            'token' => getenv('TEST_STORAGE_API_TOKEN'),
-            'config' => '123',
+            'tokenString' => getenv('TEST_STORAGE_API_TOKEN'),
+            'configId' => '123',
             'configData' => [
                 '#foo1' => $objectEncryptorFactory->getEncryptor()->encrypt('bar1', ProjectWrapper::class),
                 '#foo2' => $objectEncryptorFactory->getEncryptor()->encrypt('bar2', ComponentWrapper::class),
                 '#foo3' => $objectEncryptorFactory->getEncryptor()->encrypt('bar3', ConfigurationWrapper::class),
             ],
-            'component' => 'keboola.test',
+            'componentId' => 'keboola.test',
             'mode' => 'run',
         ];
         $job = $factory->createNewJob($data);
@@ -376,14 +376,14 @@ class JobFactoryTest extends BaseTest
         $objectEncryptorFactory->setConfigurationId('123');
         $objectEncryptorFactory->setComponentId('keboola.test1');
         $data = [
-            'token' => getenv('TEST_STORAGE_API_TOKEN'),
-            'config' => '123',
+            'tokenString' => getenv('TEST_STORAGE_API_TOKEN'),
+            'configId' => '123',
             'configData' => [
                 '#foo11' => $objectEncryptorFactory->getEncryptor()->encrypt('bar11', ProjectWrapper::class),
                 '#foo12' => $objectEncryptorFactory->getEncryptor()->encrypt('bar12', ComponentWrapper::class),
                 '#foo13' => $objectEncryptorFactory->getEncryptor()->encrypt('bar13', ConfigurationWrapper::class),
             ],
-            'component' => 'keboola.test1',
+            'componentId' => 'keboola.test1',
             'mode' => 'run',
         ];
         $jobFactory1 = new JobFactory($storageClientFactory, $objectEncryptorFactory);
@@ -393,14 +393,14 @@ class JobFactoryTest extends BaseTest
         $objectEncryptorFactory->setConfigurationId('456');
         $objectEncryptorFactory->setComponentId('keboola.test2');
         $data = [
-            'token' => getenv('TEST_STORAGE_API_TOKEN'),
-            'config' => '456',
+            'tokenString' => getenv('TEST_STORAGE_API_TOKEN'),
+            'configId' => '456',
             'configData' => [
                 '#foo21' => $objectEncryptorFactory->getEncryptor()->encrypt('bar21', ProjectWrapper::class),
                 '#foo22' => $objectEncryptorFactory->getEncryptor()->encrypt('bar22', ComponentWrapper::class),
                 '#foo23' => $objectEncryptorFactory->getEncryptor()->encrypt('bar23', ConfigurationWrapper::class),
             ],
-            'component' => 'keboola.test2',
+            'componentId' => 'keboola.test2',
             'mode' => 'run',
         ];
         $jobFactory2 = new JobFactory($storageClientFactory, $objectEncryptorFactory);
@@ -461,9 +461,9 @@ class JobFactoryTest extends BaseTest
         $storageClientFactory = new JobFactory\StorageClientFactory((string) getenv('TEST_STORAGE_API_URL'));
         $jobFactory = new JobFactory($storageClientFactory, $objectEncryptorFactory);
         $data = [
-            'token' => getenv('TEST_STORAGE_API_TOKEN'),
-            'config' => '123',
-            'component' => 'keboola.test1',
+            'tokenString' => getenv('TEST_STORAGE_API_TOKEN'),
+            'configId' => '123',
+            'componentId' => 'keboola.test1',
             'mode' => 'run',
         ];
         $jobFactory->createNewJob($data);


### PR DESCRIPTION
- refactoring klienta aby podporoval novu strukturu jobu v Internal API
- skipnute testy tykajuce sa legacy jobov, viz nizsie

Otazky:
1.  neviem ci upravit analogicy aj NewJobDefinition tzn. pole parametrov, ktore sa predavaju pri vytvarani noveho jobu. Teraz je to take nekonzistentne `config` => `configId`, `token` => `tokenString`, `row` => `configRowId`, `project` => `projectId` a urcite som este na nieco zabudol
2. myslim, ze uz nie je potreba podporovat legacy joby rovnakym sposobom ako to bolo zamyslane predtym. Demon uz nebude z DB vytahovat joby s legacy strukturou (alebo ano?). 
3. je potreba podporovat stare transformace?
4. mali by sme podporovat joby stareho orchestratoru, ale s tym, ze sa budu zakladat cez API. Orchestrator samotny je velky otaznik, ale mali by sme pocitat s touto variantou preistotu :)